### PR TITLE
Configure grafana influxdb datasoruces

### DIFF
--- a/app/docker/Dockerfile.grafana
+++ b/app/docker/Dockerfile.grafana
@@ -1,0 +1,3 @@
+FROM grafana/grafana:latest
+
+COPY configs/grafana-influxdb-datasources.yml /etc/grafana/provisioning/datasources/

--- a/app/docker/configs/grafana-influxdb-datasources.yml
+++ b/app/docker/configs/grafana-influxdb-datasources.yml
@@ -1,0 +1,14 @@
+datasources:
+
+  - name: InfluxDB - Telegraf - Dab     # name of the datasource
+    access: proxy                       # make grafana perform the requests
+    type: influxdb                      # type of the data source
+    url: http://influxdb:8086           # url of the prom instance
+    database: telegraf                  # influxdb database to use
+    is_default: true                    # whether this should be the default DS
+
+  - name: InfluxDB - Internal - Dab     # name of the datasource
+    access: proxy                       # make grafana perform the requests
+    type: influxdb                      # type of the data source
+    url: http://influxdb:8086           # url of the prom instance
+    database: _internal                 # database to use

--- a/app/docker/docker-compose.tools.yml
+++ b/app/docker/docker-compose.tools.yml
@@ -192,9 +192,13 @@ services:
       - /usr:/host/usr:ro
 
   grafana:
-    image: grafana/grafana:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.grafana
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
+    depends_on:
+      - influxdb
     networks:
       - observability
     volumes:


### PR DESCRIPTION
sets up sources for telegraf (the default) and the influxdb internal databases.