### PR TITLE
Allow tools version to be configured by env var

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 /tests
 /default.nix
 !/tests/features
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /tests/vendor
 /tests/node_modules
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project does *not* adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), opting instead for a rolling release model.
+
+Please indicate the change you have made in a section below entitled `YYYY-MM`.
+
+## 2018-09
+
+First month of life, hello world!
+
+### Changed
+
+- Allow version selection of tools via `$DAB_TOOLS_<NAME>_TAG`.
+
+### Added
+
+- Initialized Changelog

--- a/app/docker/Dockerfile.cyberchef
+++ b/app/docker/Dockerfile.cyberchef
@@ -1,3 +1,4 @@
-FROM nginx:alpine
+ARG NGINX_TAG=alpine
+FROM "nginx:$NGINX_TAG"
 
 ADD --chown=nginx:nginx https://gchq.github.io/CyberChef/cyberchef.htm /usr/share/nginx/html/index.html

--- a/app/docker/Dockerfile.grafana
+++ b/app/docker/Dockerfile.grafana
@@ -1,3 +1,4 @@
-FROM grafana/grafana:latest
+ARG GRAFANA_TAG=latest
+FROM "grafana/grafana:$GRAFANA_TAG"
 
 COPY configs/grafana-influxdb-datasources.yml /etc/grafana/provisioning/datasources/

--- a/app/docker/Dockerfile.telegraf
+++ b/app/docker/Dockerfile.telegraf
@@ -1,4 +1,5 @@
-FROM telegraf:alpine
+ARG TELEGRAF_TAG=alpine
+FROM "telegraf:$TELEGRAF_TAG"
 
 EXPOSE 9411
 EXPOSE 6514

--- a/app/docker/docker-compose.tools.yml
+++ b/app/docker/docker-compose.tools.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.cyberchef
+      args:
+        - "NGINX_TAG=${DAB_TOOLS_NGINX_TAG:-alpine}"
     ports:
       - 80
     healthcheck:
@@ -15,7 +17,7 @@ services:
       retries: 3
 
   portainer:
-    image: portainer/portainer
+    image: "portainer/portainer:${DAB_TOOLS_PORTAINER_TAG:-latest}"
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     ports:
@@ -26,7 +28,7 @@ services:
       - portainer:/data
 
   tick:
-    image: chronograf:alpine
+    image: "chronograf:${DAB_TOOLS_CHRONOGRAF_TAG:-alpine}"
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     depends_on:
@@ -56,6 +58,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.telegraf
+      args:
+        - "TELEGRAF_TAG=${DAB_TOOLS_TELEGRAF_TAG:-alpine}"
     depends_on:
       - influxdb
     networks:
@@ -74,7 +78,7 @@ services:
       retries: 3
 
   influxdb:
-    image: influxdb:alpine
+    image: "influxdb:${DAB_TOOLS_INFLUXDB_TAG:-alpine}"
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     volumes:
@@ -90,7 +94,7 @@ services:
       retries: 3
 
   kapacitor:
-    image: kapacitor:alpine
+    image: "kapacitor:${DAB_TOOLS_KAPACITOR_TAG:-alpine}"
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     networks:
@@ -113,7 +117,7 @@ services:
       retries: 3
 
   traefik:
-    image: traefik:alpine
+    image: "traefik:${DAB_TOOLS_TRAEFIK_TAG:-alpine}"
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     command:
@@ -158,7 +162,7 @@ services:
       retries: 3
 
   logspout:
-    image: gliderlabs/logspout:latest
+    image: "gliderlabs/logspout:${DAB_TOOLS_LOGSPOUT_TAG:-latest}"
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     volumes:
@@ -174,7 +178,7 @@ services:
       INACTIVITY_TIMEOUT: 1m
 
   watchtower:
-    image: v2tec/watchtower
+    image: v2tec/watchtower:latest
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     volumes:
@@ -182,7 +186,7 @@ services:
     command: --cleanup --label-enable
 
   sysdig:
-    image: sysdig/sysdig:latest
+    image: "sysdig/sysdig:${DAB_TOOLS_SYSDIG_TAG:-latest}"
     volumes:
       - /var/run/docker.sock:/host/var/run/docker.sock
       - /dev:/host/dev
@@ -195,6 +199,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.grafana
+      args:
+        - "GRAFANA_TAG=${DAB_TOOLS_GRAFANA_TAG:-latest}"
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     depends_on:
@@ -214,7 +220,7 @@ services:
       retries: 3
 
   consul:
-    image: consul:latest
+    image: "consul:${DAB_TOOLS_CONSUL_TAG:-latest}"
     labels:
       com.centurylinklabs.watchtower.enable: 'true'
     networks:
@@ -266,7 +272,7 @@ services:
     command: --redis localhost:16379
 
   redis:
-    image: redis:latest
+    image: "redis:${DAB_TOOLS_REDIS_TAG:-latest}"
     ports:
       - '16379:6379'
 

--- a/scripts/danger.sh
+++ b/scripts/danger.sh
@@ -1,8 +1,18 @@
-#!/bin/sh
+#!/usr/bin/env nix-shell
+#!nix-shell -i sh -p nodejs yarn
 # vim: ft=sh ts=4 sw=4 sts=4 noet
+
+# You can test danger locally against a pull request, for example:
+# ./scripts/danger.sh pr https://github.com/Nekroze/dab/pull/20
 set -euf
 
 cd tests
 
 yarn install
-yarn danger ci
+
+if [ "$#" -gt 0 ]; then
+	yarn danger "$@"
+else
+	yarn danger ci
+fi
+

--- a/tests/dangerfile.js
+++ b/tests/dangerfile.js
@@ -1,30 +1,53 @@
-const {danger, warn, includes} = require('danger')
+const {danger, fail, warn} = require('danger')
 
 // No PR is too small to include a description of why you made a change.
 if (danger.github.pr.body.length < 10) {
-	warn('Please include a description of your PR changes.')
+	fail('Please include a description of your PR changes.')
 }
 
 // Ensure yarn lock file is up to date.
-const changedYarn = danger.git.modified_files.includes('package.json')
-const changedYarnLock = danger.git.modified_files.includes('yarn.lock')
+const changedYarn = danger.git.modified_files.includes('package.json');
+const changedYarnLock = danger.git.modified_files.includes('yarn.lock');
 if (changedYarn && !changedYarnLock) {
-	const message = 'Changes were made to package.json, but not to yarn.lock'
-	const idea = 'Perhaps you need to run `yarn install`?'
-	warn(`${message} - <i>${idea}</i>`)
+	fail('Changes were made to package.json, but not to yarn.lock\nPerhaps you need to run `yarn install`?')
+
 }
 
-// Ensure ruby gem lock file is up to date.
-const changedGemfile = danger.git.modified_files.includes('tests/Gemfile')
-const changedGemfileLock = danger.git.modified_files.includes('tests/Gemfile.lock')
-if (changedGemfile && !changedGemfileLock) {
-	const message = 'Changes were made to tests/Gemfile, but not to tests/Gemfile.lock'
-	const idea = 'Perhaps you need to run `bundle install`?'
-	warn(`${message} - <i>${idea}</i>`)
-}
-
-const changedWrapper = danger.git.modified_files.includes('dab')
 // Changes to the dab wrapper script are to be avoided when possible.
+const changedWrapper = danger.git.modified_files.includes('dab');
 if (changedWrapper) {
 	warn('Changes to the dab wrapper script are to be avoided when possible.')
+}
+
+// Warn if changelog is not updated for non trivial patches.
+const changedChangelog = danger.git.modified_files.includes('CHANGELOG.md');
+if (!changedChangelog) {
+	warn('Please add a changelog entry for your changes')
+}
+
+// Warn if there are changes to app, but not tests
+const modifiedFiles = danger.git.modified_files
+const changesApp = modifiedFiles.filter(filepath => filepath.includes('app'));
+const changesSubcommands = changesApp.filter(filepath => filepath.includes('subcommands'));
+
+const appChanges = modifiedFiles.filter(filepath => filepath.includes('app'));
+const hasAppChanges = appChanges.length > 0;
+const testChanges = modifiedFiles.filter(filepath => filepath.includes('tests'));
+const hasTestChanges = appChanges.length > 0;
+if (hasAppChanges && !hasTestChanges) {
+	warn("There are changes to app , but not tests. That's OK as long as you're refactoring.");
+}
+
+// New subcommands should get new feature files for testing
+const correspondingTestsForSubcommandChanges = changesSubcommands.map(f => {
+	const changed = path.basename(f)
+	const test = path.basename(changed).replace('.sh', '.feature')
+	return `tests/features/${test}`
+});
+const missingTestFiles = correspondingTestsForSubcommandChanges.filter(f => fs.existsSync(f));
+if (missingTestFiles.length > 0) {
+	const output = `Missing Test Feature Files:
+	${testFilesThatDontExist.map(f => `  - [] \`${f}\``).join("\n")}
+	You cannot add a subcommand and not add some kind of test for it.`
+	fail(output)
 }

--- a/tests/features/tools.feature
+++ b/tests/features/tools.feature
@@ -48,6 +48,31 @@ Feature: Subcommand: dab tools
 			| logspout  |
 			| grafana   |
 
+	Scenario Outline: Can select different tool versions with environment variables
+		A non exhaustive list of tools and versions that can be configured.
+
+		Given I set the environment variable "<VAR>" to "<VERSION>"
+
+		When I successfully run `dab tools <TOOL> start`
+
+		Then I run `docker ps --format '{{ .Image }}' --filter 'name=tools_<TOOL>_1'`
+		And it should pass with "<VERSION>"
+		And I successfully run `dab tools <TOOL> stop`
+
+		Examples:
+			| TOOL      | VAR                      | VERSION    |
+			| tick      | DAB_TOOLS_CHRONOGRAF_TAG | latest     |
+			| tick      | DAB_TOOLS_CHRONOGRAF_TAG | alpine     |
+			| tick      | DAB_TOOLS_CHRONOGRAF_TAG | 1.5        |
+			| tick      | DAB_TOOLS_CHRONOGRAF_TAG | 1.5-alpine |
+			| tick      | DAB_TOOLS_CHRONOGRAF_TAG | 1.6-alpine |
+			| portainer | DAB_TOOLS_PORTAINER_TAG  | 1.19.2     |
+			| influxdb  | DAB_TOOLS_INFLUXDB_TAG   | 1.5-alpine |
+			| kapacitor | DAB_TOOLS_KAPACITOR_TAG  | 1.5-alpine |
+			| traefik   | DAB_TOOLS_TRAEFIK_TAG    | v1.7       |
+			| logspout  | DAB_TOOLS_LOGSPOUT_TAG   | v3.1       |
+			| consul    | DAB_TOOLS_CONSUL_TAG     | 1.1.0      |
+
 	Scenario: Can stop all tools at once
 		Given I successfully run `dab tools cyberchef start`
 


### PR DESCRIPTION
Environment variables like `$DAB_TOOLS_TELEGRAF_TAG` can now be used to select the docker tag to use for this image.

Fixes #8