### PR TITLE
Make config operations idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ First month of life, hello world!
 
 ### Changed
 
-- Allow version selection of tools via `$DAB_TOOLS_<NAME>_TAG`.
+- Config `set` and `add` operations are now idempotent
+- Allow version selection of tools via `$DAB_TOOLS_<NAME>_TAG`
 
 ### Added
 

--- a/app/lib.sh
+++ b/app/lib.sh
@@ -81,6 +81,7 @@ config_set() {
 
 	path="/etc/dab/$key"
 	if [ -n "${1:-}" ]; then
+		[ "$(carelessly cat "$path")" = "$*" ] && return 0
 		whisper "setting config key $key to $*"
 		mkdir -p "$(dirname "$path")"
 		echo "$@" >"$path"
@@ -97,6 +98,7 @@ config_add() {
 	[ -n "$1" ] || fatality "must provide some value to add"
 
 	path="/etc/dab/$key"
+	silently grep -E "^$*$" "$path" && return 0
 	mkdir -p "$(dirname "$path")"
 	echo "$@" >>"$path"
 	whisper "added $* to config key $key which now contains $(wc -l <"$path") value(s)"

--- a/tests/features/config.feature
+++ b/tests/features/config.feature
@@ -16,7 +16,12 @@ Feature: Subcommand: dab config
 	Scenario Outline: Can set and retrieve config values
 		The user should be able to get and set arbitrary config key value pairs.
 
-		Given I successfully run `dab config set <KEY> <VALUE>`
+		When I successfully run `dab config set <KEY> <VALUE>`
+
+		Then it should pass with exactly:
+		"""
+		setting config key <KEY> to <VALUE>
+		"""
 
 		When I run `dab config get <KEY>`
 
@@ -35,6 +40,32 @@ Feature: Subcommand: dab config
 			| foo     | barry    |
 			| bar.foo | 42       |
 			| bar.foo | 42 barry |
+
+	Scenario Outline: Setting config values is an idempotent operation
+		The user should be able to set a config multiple times with the same
+		value and it only apply once.
+
+		Given I successfully run `dab config set <KEY> <VALUE>`
+		And the output should contain exactly:
+		"""
+		setting config key <KEY> to <VALUE>
+		"""
+
+		When I successfully run `dab config set <KEY> <VALUE>`
+		Then the output should not contain anything
+
+		When I run `dab config get <KEY>`
+		Then it should pass with exactly:
+		"""
+		<VALUE>
+		"""
+
+		Examples:
+			| KEY     | VALUE    |
+			| soo     | lan      |
+			| soo     | larry    |
+			| dar.foo | 42       |
+			| dar.foo | 42 larry |
 
 	Scenario Outline: Can add to a config value making a list
 		The user should be able to set a config value and then add to it to
@@ -87,6 +118,30 @@ Feature: Subcommand: dab config
 		"""
 		schleem
 		"""
+
+	Scenario: Adding config values to a list is an idempotent operation
+
+		Given I successfully run `dab config add shleembop bloof`
+		And the output should contain exactly:
+		"""
+		added bloof to config key shleembop which now contains 1 value(s)
+		"""
+
+		When I successfully run `dab config add shleembop bloof`
+
+		Then the output should not contain anything
+
+	Scenario: Adding config values to non list is an idempotent operation
+
+		Given I successfully run `dab config set pewpew boom`
+		And the output should contain exactly:
+		"""
+		setting config key pewpew to boom
+		"""
+
+		When I successfully run `dab config add pewpew boom`
+
+		Then the output should not contain anything
 
 	Scenario Outline: Can erase config items with an empty set
 		By not giving a value to assign to a key when running the `config set`


### PR DESCRIPTION
`dab config set` and `dab config add` are now idempotent.
Fixes #22 
