### PR TITLE
Allow hooks to fail

### DIFF
--- a/app/lib/hooks.sh
+++ b/app/lib/hooks.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# vim: ft=sh ts=4 sw=4 sts=4 noet
+set -euf
+
+# shellcheck disable=SC1091
+. ./lib/compose.sh
+# shellcheck disable=SC1091
+. ./lib/config.sh
+# shellcheck disable=SC1091
+. ./lib/update.sh
+
+hooks() {
+	maybe_selfupdate_dab || true
+	config_load_envs || true
+
+	case "${1:-}" in
+	'-h' | '--help' | 'help' | 'network' | '')
+		true
+		;;
+	*)
+		quietly ensure_network || true
+		;;
+	esac
+}

--- a/app/main.sh
+++ b/app/main.sh
@@ -3,24 +3,9 @@
 set -euf
 
 # shellcheck disable=SC1091
-. ./lib/compose.sh
-# shellcheck disable=SC1091
-. ./lib/config.sh
-# shellcheck disable=SC1091
-. ./lib/update.sh
+. ./lib/hooks.sh
+hooks "$@"
+
 # shellcheck disable=SC1091
 . ./lib/dab.sh
-
-maybe_selfupdate_dab
-config_load_envs
-
-case "${1:-}" in
-'-h' | '--help' | 'help' | 'network' | '')
-	true
-	;;
-*)
-	quietly ensure_network
-	;;
-esac
-
 dab "$@"


### PR DESCRIPTION
Prevents subcommands from being entirely inaccesable eg when network
must be recreated.