### PR TITLE
Use current master for changelog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,11 @@ FROM alpine:latest AS versioning
 
 RUN apk add --no-cache git
 
-COPY ./ ./
+COPY ./.git ./
 
 RUN git rev-parse HEAD > /VERSION \
+ && git clone https://github.com/Nekroze/dab.git \
+ && cd dab \
  && git log --graph --pretty=format:'\e[0;31m%h\e[0m|^|%s \e[0;34m<%an>\e[0m' --abbrev-commit > /LOG
 
 

--- a/tests/features/misc.feature
+++ b/tests/features/misc.feature
@@ -36,6 +36,15 @@ Feature: Docker entrypoint wrapper script works
 		"""
 		And I copy the file "/usr/bin/dab.original" to "/usr/bin/dab"
 
+	Scenario: Can view the full changelog
+		When I run `dab changelog`
+
+		Then it should pass with:
+		"""
+		* 80e2a77|^|Init <Taylor Nekroze Lawson>
+		* 2cd1ee8|^|Initial commit <Taylor "Nekroze" Lawson>
+		"""
+
 	Scenario Outline: All sub commands groups provide usage information
 		Given I run `dab <SUBCOMMAND> --help`
 		And it should pass with "Usage:"


### PR DESCRIPTION
Should fix truncation when built by docker hub

Relates to #106