### PR TITLE
Hook to add chronograf annotations for all executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Are you ready to get STABLE!
 - `dab group groups` to allow one group to depend on other groups, started before services
 - `dab changelog` subcommand displays git history and optionally diff between revisions
 - [kafkacat](https://github.com/edenhill/kafkacat) added to tools pointing at kafka service by default
+- Chronograf annotations hook to record each dab run
 
 ### Fixed
 

--- a/app/lib/hooks.sh
+++ b/app/lib/hooks.sh
@@ -9,7 +9,23 @@ set -euf
 # shellcheck disable=SC1091
 . ./lib/update.sh
 
+influx() {
+	servicepose run --rm influxdb influx -host services_influxdb_1 "$@"
+}
+
+maybe_post_chronograf_annotiation() {
+	if ! silently docker top services_influxdb_1; then
+		return 0
+	fi
+	ns="$(date +%s)000000000"
+	values="text=\"dab $1\",start_time=${ns}i,modified_time_ns=${ns}i,type=\"dab execution\",deleted=false"
+	influx -database chronograf -execute "INSERT annotations,id=$(uuidgen) $values" || influx -execute 'CREATE DATABASE chronograf'
+}
+
 hooks() {
+	quietly maybe_post_chronograf_annotiation "$*" || true &
+	trap 'wait $(jobs -p)' EXIT
+
 	config_load_envs || true
 	maybe_notify_wrapper_update || true
 	maybe_update_completion || true


### PR DESCRIPTION
Should only have a performance impact on short commands when influxdb service is running.