### PR TITLE
Allow limiting config key output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Are you ready to get STABLE!
 - Use go 1.11 modules for completion binary, pins dependencies and improves docker build caching
 - Deprecated `compose-external-default-network.sh`
 - Reversed changelog output, newest changes are at the bottom
+- `dab config keys` can now take a config key to limit its output
 
 ### Added
 

--- a/app/lib/config.sh
+++ b/app/lib/config.sh
@@ -6,7 +6,7 @@ set -euf
 . ./lib/output.sh
 
 config_get() {
-	path="$DAB_CONF_PATH/$1"
+	path="$(config_path "$1")"
 	[ ! -r "$path" ] || cat "$path"
 }
 

--- a/app/subcommands/config/keys
+++ b/app/subcommands/config/keys
@@ -1,9 +1,19 @@
 #!/bin/sh
 # Description: View all set config keys as a tree branching at a / in each key
+# Usage: [<KEY>]
 # vim: ft=sh ts=4 sw=4 sts=4 noet
 set -euf
 
-cd "$DAB_CONF_PATH"
+# shellcheck disable=SC1091
+. ./lib/config.sh
+# shellcheck disable=SC1091
+. ./lib/output.sh
+
+path="$(config_path "${1:-}")"
+
+[ -d "$path" ] || fatality 'Provided config key is not a namespace or does not exist'
+
+cd "$path"
 # Remove first, last, and empty lines from tree output
 tree | sed \
 	-e '1 d' \

--- a/tests/features/config.feature
+++ b/tests/features/config.feature
@@ -30,6 +30,20 @@ Feature: Subcommand: dab config
 			| bar.foo | 42       |
 			| bar.foo | 42 barry |
 
+	Scenario: Can display a tree of config keys
+		Given I successfully run `dab config set flume/log foo`
+
+		When I run `dab config keys`
+
+		Then it should pass with "├── flume"
+
+	Scenario: Can display a tree of config keys at a specific namespace
+		Given I successfully run `dab config set boogie/nights 2`
+
+		When I run `dab config keys boogie`
+
+		Then it should pass with "└── nights"
+
 	Scenario Outline: Can add to a config value making a list
 		Config values can also be a list of values, represented by lines in a
 		file. Note setting will replace the list with the single new element.

--- a/tests/features/services.feature
+++ b/tests/features/services.feature
@@ -22,7 +22,7 @@ Feature: Subcommand: dab services
 		Then it should pass with "Pulling"
 		And the output should contain "Building"
 
-	Scenario Outline: Can start and stop web based services
+	Scenario Outline: Can start and stop services
 		When I run `dab services start <SERVICE>`
 
 		Then the exit status should be 0
@@ -34,18 +34,17 @@ Feature: Subcommand: dab services
 		And it should fail with "is not running"
 
 		Examples:
-			| SERVICE       |
-			| influxdb      |
-			| telegraf      |
-			| elasticsearch |
-			| logspout      |
-			| redis         |
-			| postgres      |
-			| vault         |
-			| consul        |
-			| mysql         |
-			| memcached     |
-			| nats          |
+			| SERVICE   |
+			| influxdb  |
+			| telegraf  |
+			| logspout  |
+			| redis     |
+			| postgres  |
+			| vault     |
+			| consul    |
+			| mysql     |
+			| memcached |
+			| nats      |
 
 	Scenario Outline: Can select different service versions with environment variables
 		A non exhaustive list of services and versions that can be configured.


### PR DESCRIPTION
No parameter will give the same output but can take a config key to
scope the output

Fixes #130