### PR TITLE
Deprecate compose-external-default-network.sh in favor of docker-compose-gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Are you ready to get STABLE!
 - Remove all pki config keys (including keys and certs) when doing `dab pki destroy`
 - Added pgadmin and adminer to the lab network for access to lab containers
 - Use go 1.11 modules for completion binary, pins dependencies and improves docker build caching
+- Deprecated `compose-external-default-network.sh`
 
 ### Added
 
@@ -75,6 +76,7 @@ Are you ready to get STABLE!
 - Kibana to tools
 - Subcommand aliases
 - `dab repo entrypoint run` to allow execution of any entrypoint
+- docker-compose-gen
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The [dab script][1] wrapper has been designed to reduce the requirement to updat
 - Automatically detect out of date wrapper script
 - Groups allow combining repositories, services, tools, and even groups to be orchestrated together
 - Shared base image, most all docker container dab uses utilize an alpine base image that is lean
-- Simple, thanks to the [subcommander](https://github.com/Nekroze/subcommander) dispatcher most subcommands are implemented in only a few SLOC
+- Simple, thanks to the [subcommander][7] dispatcher most subcommands are implemented in only a few SLOC
 - Tree structured configuration that can be shared (eg. via git or tar)
 - x509 PKI managed via [Vault][5] with transparent certificate renewal via [VaultBot][6]
 
@@ -95,9 +95,30 @@ The [dab script][1] wrapper has been designed to reduce the requirement to updat
 
 If you would like to help hone dab into a better tool check out our [contributing][2] documentation.
 
+## Bill Of Materials
+
+The following projects are used to write dab:
+
+- [Subcommander][7]
+- [ContainAruba][8]
+- [docker-compose-gen][9]
+- [yq][10]
+- [jq][11]
+- [docker-compose][12]
+- [shellcheck][13]
+- [complete][14]
+
 [1]: https://github.com/Nekroze/dab/raw/master/dab
 [2]: https://github.com/Nekroze/dab/blob/master/CONTRIBUTING.md
 [3]: https://www.influxdata.com/time-series-platform/
 [4]: https://github.com/gliderlabs/logspout
 [5]: https://www.vaultproject.io/
 [6]: https://gitlab.com/msvechla/vaultbot
+[7]: https://github.com/Nekroze/subcommander
+[8]: https://github.com/Nekroze/containaruba
+[9]: https://github.com/Nekroze/docker-compose-gen
+[10]: https://github.com/kislyuk/yq
+[11]: https://stedolan.github.io/jq/
+[12]: https://github.com/docker/compose
+[13]: https://github.com/koalaman/shellcheck
+[14]: github.com/posener/complete

--- a/app/bin/dab
+++ b/app/bin/dab
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -euf
+
+# shellcheck disable=SC1090
+. "$DAB/lib/dab.sh"
+
+dab "$@"

--- a/app/default-entrypoint.sh
+++ b/app/default-entrypoint.sh
@@ -2,8 +2,5 @@
 set -eu
 
 # Put containers on the lab network by default.
-COMPOSE_FILE="docker-compose.yml:$(compose-external-default-network.sh 2.1 lab default)"
+COMPOSE_FILE="docker-compose.yml:$(docker-compose-gen network --external lab)"
 export COMPOSE_FILE
-
-# shellcheck disable=SC1090
-. "$DAB/lib/dab.sh"

--- a/app/main.sh
+++ b/app/main.sh
@@ -21,6 +21,4 @@ SUBCOMMANDS="$DAB/subcommands"
 
 export APPLICATION DESCRIPTION VERSION SUBCOMMANDS
 
-# shellcheck disable=SC1091
-. ./lib/dab.sh
 dab "$@"

--- a/app/subcommands/group/start
+++ b/app/subcommands/group/start
@@ -6,8 +6,6 @@ set -euf
 
 # shellcheck disable=SC1091
 . ./lib/config.sh
-# shellcheck disable=SC1091
-. ./lib/dab.sh
 
 [ -n "${1:-}" ] || fatality 'must provide a group name to add too'
 group_name="$1"

--- a/app/subcommands/group/update
+++ b/app/subcommands/group/update
@@ -8,8 +8,6 @@ set -euf
 . ./lib/config.sh
 # shellcheck disable=SC1091
 . ./lib/update.sh
-# shellcheck disable=SC1091
-. ./lib/dab.sh
 
 [ -n "${1:-}" ] || fatality 'must provide a group name to add too'
 group_name="$1"

--- a/app/subcommands/pki/destroy
+++ b/app/subcommands/pki/destroy
@@ -3,8 +3,5 @@
 # vim: ft=sh ts=4 sw=4 sts=4 noet
 set -euf
 
-# shellcheck disable=SC1091
-. ./lib/dab.sh
-
 dab services destroy consul vault || true
 dab config set pki

--- a/app/subcommands/repo/add
+++ b/app/subcommands/repo/add
@@ -6,8 +6,6 @@ set -euf
 
 # shellcheck disable=SC1091
 . ./lib/config.sh
-# shellcheck disable=SC1091
-. ./lib/dab.sh
 
 [ -n "${1:-}" ] || fatality 'must provide a repo name as the first parameter'
 [ -n "${2:-}" ] || fatality 'must provide a repo url as the second parameter'

--- a/app/subcommands/repo/entrypoint/run
+++ b/app/subcommands/repo/entrypoint/run
@@ -6,8 +6,6 @@ set -euf
 
 # shellcheck disable=SC1091
 . ./lib/config.sh
-# shellcheck disable=SC1091
-. ./lib/dab.sh
 
 [ -n "${1:-}" ] || fatality 'must provide a repo name'
 repo="$1"

--- a/app/subcommands/repo/list
+++ b/app/subcommands/repo/list
@@ -5,8 +5,6 @@ set -euf
 
 # shellcheck disable=SC1091
 . ./lib/update.sh
-# shellcheck disable=SC1091
-. ./lib/dab.sh
 
 dab repo fetch
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,4 +26,4 @@ docker-compose build --force-rm tests
 docker-compose run --rm build
 
 # run tests container and pass any params to this script to cucumber.
-docker-compose run tests "$@"
+docker-compose run tests --order=random "$@"


### PR DESCRIPTION
Old command still exists but the new one is used for new entry points