### PR TITLE
Do not use hosts /etc/passwd when UID is not in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Please indicate the change you have made in a section below entitled `YYYY-MM`.
 
+## 2018-11
+
+### Changed
+
+- Support a `DAB_UID` that is not in /etc/passwd without being an unknown user
+
 ## 2018-10
 
 Are you ready to get STABLE!

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,8 @@ ENV DAB="/opt/dab" \
 WORKDIR /opt/dab
 ADD https://github.com/mikefarah/yq/releases/download/2.1.1/yq_linux_amd64 /usr/bin/yq
 ADD https://raw.githubusercontent.com/Nekroze/subcommander/master/subcommander /usr/bin/subcommander
-RUN chmod 755 /usr/bin/yq /usr/bin/subcommander
+RUN chmod 755 /usr/bin/yq /usr/bin/subcommander \
+ && chmod 666 /etc/passwd
 COPY --from=shellcheck /bin/shellcheck /usr/bin/
 COPY --from=completion /go/src/app/completion/completion /usr/bin/dab-completion
 COPY --from=gen /docker-compose-gen /usr/bin/docker-compose-gen

--- a/app/lib/hooks.sh
+++ b/app/lib/hooks.sh
@@ -44,10 +44,20 @@ maybe_display_tip() {
 	fi
 }
 
+sane_user() {
+	# this will only write to /etc/passwd when writable, by default it is not
+	# and most often it is bind mounted read only.
+	if ! silently whoami; then
+		echo "$DAB_USER:x:$DAB_UID:$DAB_GID:user:$HOME:/bin/sh" >>/etc/passwd
+	fi
+}
+
 pre_hooks() {
 	trap post_hooks EXIT
 
 	quietly maybe_post_chronograf_annotiation "$*" || true
+
+	sane_user
 
 	DAB_SERVICES_VAULT_TOKEN="$(vault_token)"
 	export DAB_SERVICES_VAULT_TOKEN

--- a/dab
+++ b/dab
@@ -60,7 +60,9 @@ dArg \
 	-e "HOME=$HOME"
 
 # Docker user and group lists access if it exists on the host.
-[ -f /etc/passwd ] && dArg -v '/etc/passwd:/etc/passwd:ro'
+if [ -f /etc/passwd ]; then
+	cut -d':' -f 3 /etc/passwd | grep "^$DAB_UID$" >/dev/null 2>&1 && dArg -v '/etc/passwd:/etc/passwd:ro'
+fi
 [ -f /etc/group ] && dArg -v '/etc/group:/etc/group:ro'
 
 # Add the docker user explicitly to the groups dab has access too when

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,4 +26,6 @@ docker-compose build --force-rm tests
 docker-compose run --rm build
 
 # run tests container and pass any params to this script to cucumber.
-docker-compose run tests "${1:---order=random}"
+args="$*"
+[ -n "$args" ] || args='--order=random'
+docker-compose run tests $args

--- a/tests/features/misc.feature
+++ b/tests/features/misc.feature
@@ -62,3 +62,10 @@ Feature: Docker entrypoint wrapper script works
 		When I run `dab config set tips/last`
 
 		Then it should pass with "[tips:dab]"
+
+	Scenario: Can set a UID unknown to the hosts /etc/passwd
+		Given  I set the environment variable "DAB_UID" to "1337"
+
+		When I run `dab shell whoami`
+
+		Then it should pass with "user"


### PR DESCRIPTION
Instead make a temporary user, should allow for single sign on users.

Fixes #145