### PR TITLE
Do not remove orphans all the time, prevents services killing tools

### DIFF
--- a/app/subcommands/services/destroy
+++ b/app/subcommands/services/destroy
@@ -13,5 +13,5 @@ if [ -n "${1:-}" ]; then
 	dpose services rm --stop -v -f "$@"
 	docker volume rm "dab_$1"
 else
-	dpose services down --remove-orphans --volumes
+	dpose services down --volumes
 fi

--- a/app/subcommands/services/start
+++ b/app/subcommands/services/start
@@ -9,7 +9,7 @@ set -euf
 # shellcheck disable=SC1091
 . ./lib/output.sh
 
-dpose services up --remove-orphans -d "$@"
+dpose services up -d "$@"
 
 service="${1:-}"
 # If there was no service (eg when starting all) stop here

--- a/app/subcommands/tools/destroy
+++ b/app/subcommands/tools/destroy
@@ -11,5 +11,5 @@ if [ -n "${1:-}" ]; then
 	dpose tools rm --stop -v -f "$@"
 	docker volume rm "dab_$1"
 else
-	dpose tools down --remove-orphans --volumes
+	dpose tools down --volumes
 fi

--- a/app/subcommands/tools/start
+++ b/app/subcommands/tools/start
@@ -9,7 +9,7 @@ set -euf
 # shellcheck disable=SC1091
 . ./lib/output.sh
 
-dpose tools up --remove-orphans -d "$@"
+dpose tools up -d "$@"
 
 tool="${1:-}"
 # If there was no tool (eg when starting all) stop here


### PR DESCRIPTION
fixes a bug where destroying a single service removes all tools