### PR TITLE
Now telegraf logs are less noisy, disable its quiet switch

### DIFF
--- a/app/docker/configs/docker-gen/templates/telegraf.conf.tmpl
+++ b/app/docker/configs/docker-gen/templates/telegraf.conf.tmpl
@@ -68,7 +68,7 @@
   ## Run telegraf with debug log messages.
   debug = false
   ## Run telegraf in quiet mode (error log messages only).
-  quiet = true
+  quiet = false
   ## Specify the log file name. The empty string means to log to stderr.
   logfile = ""
 

--- a/app/docker/configs/vault.hcl
+++ b/app/docker/configs/vault.hcl
@@ -10,8 +10,3 @@ listener "tcp" {
 	address = "0.0.0.0:8200"
 	tls_disable = 1
 }
-
-telemetry {
-  dogstatsd_addr   = "telegraf:8125"
-  disable_hostname = true
-}

--- a/tests/features/services.feature
+++ b/tests/features/services.feature
@@ -35,7 +35,6 @@ Feature: Subcommand: dab services
 		Examples:
 			| SERVICE   |
 			| influxdb  |
-			| telegraf  |
 			| logspout  |
 			| redis     |
 			| postgres  |


### PR DESCRIPTION
Also stop testing it in CI, dynamic config seems to make CI flakey