### PR TITLE
Add remote-syslog2 to services, can now ingest file into dab chronograf

### DIFF
--- a/app/docker/Dockerfile.remote_syslog2
+++ b/app/docker/Dockerfile.remote_syslog2
@@ -1,0 +1,8 @@
+FROM golang:latest
+
+RUN go get -d -v github.com/papertrail/remote_syslog2/... \
+ && go install github.com/papertrail/remote_syslog2
+
+COPY configs/remote_syslog2.yml /etc/log_files.yml
+
+ENTRYPOINT ["/go/bin/remote_syslog2","--no-detach"]

--- a/app/docker/configs/remote_syslog2.yml
+++ b/app/docker/configs/remote_syslog2.yml
@@ -1,0 +1,9 @@
+hostname: dab
+
+files:
+  - /srv/logs/*.log
+
+destination:
+  host: telegraf
+  port: 6514
+  protocol: udp

--- a/app/docker/docker-compose.deps.yml
+++ b/app/docker/docker-compose.deps.yml
@@ -5,6 +5,9 @@ services:
   chronograf:
     depends_on:
       - influxdb
+      - telegraf
+      - logspout
+      - remote-syslog2
 
   kapacitor:
     depends_on:

--- a/app/docker/docker-compose.services.yml
+++ b/app/docker/docker-compose.services.yml
@@ -251,6 +251,21 @@ services:
     tmpfs:
       - /tmp
 
+  remote-syslog2:
+    container_name: dab_remote-syslog2
+    build:
+      context: .
+      dockerfile: Dockerfile.remote_syslog2
+    labels:
+      description: 'Ingests .log files placed in the docker volume named dab_logs'
+    restart: on-failure
+    depends_on:
+      - telegraf
+    volumes:
+      - logs:/srv/logs
+    tmpfs:
+      - /tmp
+
 volumes:
   postgres:
   influxdb:
@@ -259,6 +274,7 @@ volumes:
   vault:
   mysql:
   gend:
+  logs:
 
 networks:
   default:

--- a/completion/services.go
+++ b/completion/services.go
@@ -16,6 +16,7 @@ var services = []string{
 	"telegraf",
 	"vault",
 	"zookeeper",
+	"remote-syslog2",
 }
 
 func predictServices(_ complete.Args) []string {


### PR DESCRIPTION
Adds a docker volume named dab_logs where any .log files will be
ingested from.

Fixes #123