### PR TITLE
Add Fn Project to services

### DIFF
--- a/app/docker/Dockerfile.fn
+++ b/app/docker/Dockerfile.fn
@@ -1,0 +1,29 @@
+FROM alpine:latest AS download
+
+ARG FN_VERSION=0.5.29
+RUN wget --quiet -O /usr/bin/fn "https://github.com/fnproject/cli/releases/download/${FN_VERSION}/fn_linux" \
+ && chmod 755 /usr/bin/fn
+
+FROM debian:stable-slim AS final
+
+RUN apt-get update \
+ && apt-get install -y \
+     apt-transport-https \
+     ca-certificates \
+     curl \
+     gnupg2 \
+     software-properties-common \
+ && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+ && add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable" \
+ && apt-get update \
+ && apt-get install -y docker-ce \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=download /usr/bin/fn /usr/bin/fn
+ENTRYPOINT ["/usr/bin/fn"]
+CMD start
+
+VOLUME /app/data

--- a/app/docker/docker-compose.services.yml
+++ b/app/docker/docker-compose.services.yml
@@ -286,6 +286,29 @@ services:
     tmpfs:
       - /tmp
 
+  fn:
+    container_name: dab_fn
+    build:
+      context: .
+      dockerfile: Dockerfile.fn
+      args:
+        - "FN_VERSION=${DAB_SERVICES_FN_VERSION:-0.5.29}"
+    labels:
+      description: 'Open Source, Container-native, Serverless platform'
+    environment:
+      HOME:
+      FN_DOCKER_NETWORKS: 'lab'
+    command: start
+    user: "${DAB_UID}:${DAB_DOCKER_GID}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - "$HOME:$HOME"
+      - "$HOST_PWD:$HOST_PWD"
+    working_dir: "$HOST_PWD"
+    restart: on-failure
+    tmpfs:
+      - /tmp
+
 volumes:
   postgres:
   influxdb:

--- a/app/lib/docker.sh
+++ b/app/lib/docker.sh
@@ -48,7 +48,7 @@ compose_service_to_urls() {
 	service="$2"
 	scheme="$(get_compose_service_label_value "$project" "$service" exposing http)"
 	id="$(ishmael find dab "$service" || fatality "$service is not running")"
-	ishmael address "$id" | xargs printf "$scheme://%s\\n"
+	ishmael address "$id" | xargs --no-run-if-empty printf "$scheme://%s\\n"
 }
 
 await_container_healthy_timeout=60

--- a/app/lib/update.sh
+++ b/app/lib/update.sh
@@ -39,7 +39,7 @@ maybe_selfupdate_dab() {
 	if should_selfupdate; then
 		inform "self updating dab!"
 		config_set updates/last "$(date +%s)"
-		docker pull nekroze/dab:latest
+		docker pull "${DAB_IMAGE:-${DAB_IMAGE_NAMESPACE:-nekroze}/${DAB_IMAGE_NAME:-dab}:${DAB_IMAGE_TAG:-latest}}"
 		/tmp/wrapper changelog "$(cut -c -7 </VERSION)"
 	fi
 }

--- a/app/subcommands/services/address
+++ b/app/subcommands/services/address
@@ -13,4 +13,4 @@ set -euf
 service="$1"
 
 msgfmt="${COLOR_CYAN}$service is available at ${COLOR_BLUE}%s${COLOR_NC}\\n"
-compose_service_to_urls services "$service" | xargs printf "$msgfmt"
+compose_service_to_urls services "$service" | xargs --no-run-if-empty printf "$msgfmt"

--- a/app/subcommands/services/update
+++ b/app/subcommands/services/update
@@ -7,5 +7,5 @@ set -euf
 # shellcheck disable=SC1091
 . ./lib/docker.sh
 
-dpose services pull --include-deps "$@"
+dpose services pull --include-deps "$@" || true
 dpose services build --parallel --pull --force-rm "$@"

--- a/app/subcommands/tools/address
+++ b/app/subcommands/tools/address
@@ -13,4 +13,4 @@ set -euf
 tool="$1"
 
 msgfmt="${COLOR_CYAN}$tool is available at ${COLOR_BLUE}%s${COLOR_NC}\\n"
-compose_service_to_urls tools "$tool" | xargs printf "$msgfmt"
+compose_service_to_urls tools "$tool" | xargs --no-run-if-empty printf "$msgfmt"

--- a/app/subcommands/tools/update
+++ b/app/subcommands/tools/update
@@ -7,5 +7,5 @@ set -euf
 # shellcheck disable=SC1091
 . ./lib/docker.sh
 
-dpose tools pull --include-deps "$@"
+dpose tools pull --include-deps "$@" || true
 dpose tools build --parallel --pull --force-rm "$@"

--- a/dab
+++ b/dab
@@ -3,7 +3,7 @@
 set -euf
 
 # Some static values to get us started.
-image='nekroze/dab:latest'
+image="${DAB_IMAGE:-${DAB_IMAGE_NAMESPACE:-nekroze}/${DAB_IMAGE_NAME:-dab}:${DAB_IMAGE_TAG:-latest}}"
 docker_args='--hostname dab --rm --tmpfs /run,/tmp'
 
 # just a little helper to keep things readable when declaring parameters to be

--- a/dab
+++ b/dab
@@ -65,6 +65,7 @@ dArg \
 if [ -r /etc/group ]; then
 	docker_gid="$(grep '^docker:' /etc/group | cut -d: -f3)"
 	if [ -n "$docker_gid" ]; then
+		export DAB_DOCKER_GID="$docker_gid"
 		dArg --group-add "$docker_gid"
 	fi
 fi

--- a/tests/features/services.feature
+++ b/tests/features/services.feature
@@ -50,6 +50,7 @@ Feature: Subcommand: dab services
 			| consul         |
 			| docker-gen     |
 			| elasticsearch  |
+			| fn             |
 			| influxdb       |
 			| kafka          |
 			| logspout       |


### PR DESCRIPTION
Fn Project is a serverless framework facilitating functions as a service.

Also Fixes up some issues with updating and displaying addresses for services and tools, tc..