### PR TITLE
Explore subcommand and more apps on the lab network

### DIFF
--- a/app/docker/docker-compose.couchdb.yml
+++ b/app/docker/docker-compose.couchdb.yml
@@ -15,6 +15,9 @@ services:
     restart: on-failure
     tmpfs:
       - /tmp
+    networks:
+      - default
+      - lab
 
 volumes:
   couchdb:
@@ -22,3 +25,6 @@ volumes:
 networks:
   default:
     name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/app/docker/docker-compose.elasticsearch.yml
+++ b/app/docker/docker-compose.elasticsearch.yml
@@ -19,7 +19,13 @@ services:
       retries: 3
     tmpfs:
       - /tmp
+    networks:
+      - default
+      - lab
 
 networks:
   default:
     name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/app/docker/docker-compose.influxdb.yml
+++ b/app/docker/docker-compose.influxdb.yml
@@ -22,6 +22,9 @@ services:
       retries: 3
     tmpfs:
       - /tmp
+    networks:
+      - default
+      - lab
 
 volumes:
   influxdb:
@@ -29,3 +32,6 @@ volumes:
 networks:
   default:
     name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/app/docker/docker-compose.kafka.yml
+++ b/app/docker/docker-compose.kafka.yml
@@ -11,6 +11,9 @@ services:
     depends_on:
       - zookeeper
     restart: on-failure
+    networks:
+      - default
+      - lab
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
@@ -20,6 +23,8 @@ services:
       - /tmp
 
 networks:
+  default:
+    name: dab_apps
   lab:
     external:
       name: lab

--- a/app/docker/docker-compose.memcached.yml
+++ b/app/docker/docker-compose.memcached.yml
@@ -12,7 +12,13 @@ services:
     restart: on-failure
     tmpfs:
       - /tmp
+    networks:
+      - default
+      - lab
 
 networks:
   default:
     name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/app/docker/docker-compose.minio.yml
+++ b/app/docker/docker-compose.minio.yml
@@ -21,6 +21,9 @@ services:
     restart: on-failure
     tmpfs:
       - /tmp
+    networks:
+      - default
+      - lab
 
 volumes:
   minio:
@@ -28,3 +31,6 @@ volumes:
 networks:
   default:
     name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/app/docker/docker-compose.mysql.yml
+++ b/app/docker/docker-compose.mysql.yml
@@ -16,6 +16,9 @@ services:
       - mysql:/var/lib/mysql
     tmpfs:
       - /tmp
+    networks:
+      - default
+      - lab
 
 volumes:
   mysql:
@@ -23,3 +26,6 @@ volumes:
 networks:
   default:
     name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/app/docker/docker-compose.postgres.yml
+++ b/app/docker/docker-compose.postgres.yml
@@ -14,6 +14,9 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - postgres:/var/lib/postgresql/data/pgdata
+    networks:
+      - default
+      - lab
     tmpfs:
       - /tmp
 
@@ -23,3 +26,6 @@ volumes:
 networks:
   default:
     name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/app/docker/docker-compose.redis.yml
+++ b/app/docker/docker-compose.redis.yml
@@ -21,7 +21,13 @@ services:
       - '16379:6379'
     tmpfs:
       - /tmp
+    networks:
+      - default
+      - lab
 
 networks:
   default:
     name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/app/subcommands/apps/explore
+++ b/app/subcommands/apps/explore
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Description: Open a shell in a temporary instance of the given app
+# Usage: <APP_NAME>
+# vim: ft=sh ts=4 sw=4 sts=4 noet
+set -euf
+
+# shellcheck disable=SC1090
+. "$DAB/lib/docker.sh"
+# shellcheck disable=SC1090
+. "$DAB/lib/output.sh"
+
+[ -n "${1:-}" ] || fatality 'must provide an app name'
+app="$1"
+shift
+
+dpose "$app" run --entrypoint /bin/sh --rm "$app"


### PR DESCRIPTION
attaching projects to the dab_apps network is a bit gross but putting the most likely apps to directly interface with your projects on the lab network then they resolve to their compose service name by default so kafka is kafka etc.