### PR TITLE
Remove tmpfs from apps that need exec /tmp and ballerina host networking

### DIFF
--- a/app/docker/docker-compose.ballerina.yml
+++ b/app/docker/docker-compose.ballerina.yml
@@ -9,15 +9,13 @@ services:
       description: 'IDE and language designed to make integration simple.'
       com.centurylinklabs.watchtower.enable: 'true'
     restart: on-failure
+    network_mode: host
     command:
       - 'composer'
-      - '--host 0.0.0.0'
-    expose:
-      - 9091
+    ports:
+      - '9091:9091'
     volumes:
-      - "$DAB_REPO_PATH:/home/ballerina"
-    tmpfs:
-      - /tmp
+      - "$DAB_REPO_PATH:$DAB_REPO_PATH"
 
 networks:
   default:

--- a/app/docker/docker-compose.kafka-rest.yml
+++ b/app/docker/docker-compose.kafka-rest.yml
@@ -21,8 +21,6 @@ services:
     expose:
       - 8082
     restart: on-failure
-    tmpfs:
-      - /tmp
 
 networks:
   default:

--- a/app/docker/docker-compose.kafka.yml
+++ b/app/docker/docker-compose.kafka.yml
@@ -19,8 +19,6 @@ services:
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_LOG4J_ROOT_LOGLEVEL: WARN
-    tmpfs:
-      - /tmp
 
 networks:
   default:

--- a/app/docker/docker-compose.zookeeper.yml
+++ b/app/docker/docker-compose.zookeeper.yml
@@ -12,8 +12,6 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: WARN
-    tmpfs:
-      - /tmp
 
 networks:
   default:


### PR DESCRIPTION
Fixes some kafka clients and makes ballerina web IDE usable.