### PR TITLE
Install root CA via mitm.it not intermediate when using mitmproxy

### DIFF
--- a/app/subcommands/pki/ready
+++ b/app/subcommands/pki/ready
@@ -36,7 +36,7 @@ if ! vault_pki_enabled; then
 	vault secrets enable -path=pki_dab pki
 	vault write pki_dab/config/urls issuing_certificates='http://vault:8200/v1/pki_dab'
 	vault secrets tune -max-lease-ttl="$DAB_PKI_CA_TTL" pki_dab
-	ca_cert="$(carelessly vault write -format=json -field=certificate pki_dab/root/generate/internal common_name=dab ttl="$DAB_PKI_CA_TTL")"
+	ca_cert="$(carelessly vault write -format=json -field=certificate pki_dab/root/generate/internal common_name="dab_$DAB_USER" ttl="$DAB_PKI_CA_TTL")"
 	config_set pki/ca/certificate "$(echo "$ca_cert" | jq -r)"
 	config_chmod pki/ca/certificate 640
 
@@ -65,10 +65,12 @@ if ! vault_pki_enabled; then
 		inform "Installed CA Certificate into $(dirname "$db")"
 	done
 
-	if [ ! -f ~/.mitmproxy/mitmproxy-ca.pem ] || [ -w ~/.mitmproxy/mitmproxy-ca.pem ]; then
+	if [ ! -f ~/.mitmproxy/mitmproxy-ca.pem ] || [ ! -f ~/.mitmproxy/mitmproxy-ca-cert.pem ]; then
 		cp "$DAB_CONF_PATH/pki/int/bundle" "$HOME/.mitmproxy/mitmproxy-ca.pem"
+		cp "$DAB_CONF_PATH/pki/ca/certificate" "$HOME/.mitmproxy/mitmproxy-ca-cert.pem"
 	else
 		warn "Could not install Intermediate CA for mitmproxy"
 		warn "Please copy $DAB_CONF_PATH/pki/int/bundle to $HOME/.mitmproxy/mitmproxy-ca.pem"
+		warn "Please copy $DAB_CONF_PATH/pki/ca/certificate to $HOME/.mitmproxy/mitmproxy-ca-cert.pem"
 	fi
 fi


### PR DESCRIPTION
The intermediate does not well install into some devices whereas the root does