### PR TITLE
'dab update' now ignores DAB_AUTOUPDATE allowing for usage on demand

### DIFF
--- a/app/subcommands/update
+++ b/app/subcommands/update
@@ -7,5 +7,5 @@ set -euf
 . "$DAB/lib/update.sh"
 
 export self_update_period=10
-maybe_selfupdate_dab
+DAB_AUTOUPDATE=true maybe_selfupdate_dab
 maybe_update_wrapper


### PR DESCRIPTION
recent changes make the DAB_AUTOUPDATE environment variables inheritable made it impossible to run `dab update` to manually ask for an update.