### PR TITLE
Add burrow app to monitor kafka lag

### DIFF
--- a/app/docker/configs/docker-gen/templates/telegraf.conf.tmpl
+++ b/app/docker/configs/docker-gen/templates/telegraf.conf.tmpl
@@ -1035,3 +1035,48 @@
 [[inputs.zipkin]]
   path = "/api/v1/spans" # URL path for span data
   port = 9411            # Port on which Telegraf listens
+
+{{ range $ci, $container := whereLabelValueMatches (whereLabelValueMatches . "com.docker.compose.project" "dab") "com.docker.compose.service" "burrow" }}
+[[inputs.burrow]]
+  ## Burrow API endpoints in format "schema://host:port".
+  ## Default is "http://localhost:8000".
+  servers = ["http://dab_burrow:8000"]
+
+  ## Override Burrow API prefix.
+  ## Useful when Burrow is behind reverse-proxy.
+  # api_prefix = "/v3/kafka"
+
+  ## Maximum time to receive response.
+  # response_timeout = "5s"
+
+  ## Limit per-server concurrent connections.
+  ## Useful in case of large number of topics or consumer groups.
+  # concurrent_connections = 20
+
+  ## Filter clusters, default is no filtering.
+  ## Values can be specified as glob patterns.
+  # clusters_include = []
+  # clusters_exclude = []
+
+  ## Filter consumer groups, default is no filtering.
+  ## Values can be specified as glob patterns.
+  # groups_include = []
+  # groups_exclude = []
+
+  ## Filter topics, default is no filtering.
+  ## Values can be specified as glob patterns.
+  # topics_include = []
+  # topics_exclude = []
+
+  ## Credentials for basic HTTP authentication.
+  # username = ""
+  # password = ""
+
+  ## Optional SSL config
+  # ssl_ca = "/etc/telegraf/ca.pem"
+  # ssl_cert = "/etc/telegraf/cert.pem"
+  # ssl_key = "/etc/telegraf/key.pem"
+  # insecure_skip_verify = false
+{{ end }}
+
+

--- a/app/docker/docker-compose.burrow.yml
+++ b/app/docker/docker-compose.burrow.yml
@@ -1,0 +1,33 @@
+version: '3.5'
+
+services:
+
+  burrow:
+    container_name: dab_burrow
+    image: 'nekroze/burrow:latest'
+    labels:
+      description: 'Kafka Consumer Lag Checking'
+      com.centurylinklabs.watchtower.enable: 'true'
+    environment:
+        BURROW_ZOOKEEPER_SERVERS: "${DAB_APPS_BURROW_TARGET_ZOOKEEPER:-zookeeper}:2181"
+        BURROW_CLUSTER_LOCAL_SERVERS: "${DAB_APPS_BURROW_TARGET_KAFKA:-kafka}:9092"
+        BURROW_CONSUMER_LOCAL_SERVERS: "${DAB_APPS_BURROW_TARGET_KAFKA:-kafka}:9092"
+        BURROW_CONSUMER_LOCAL_GROUP-BLACKLIST: '^(console-consumer-|python-kafka-consumer-).*$$'
+        BURROW_CONSUMER_LOCAL_ZK_SERVERS: "${DAB_APPS_BURROW_TARGET_ZOOKEEPER:-zookeeper}:2181"
+        BURROW_CONSUMER_LOCAL_ZK_GROUP-BLACKLIST: '^(console-consumer-|python-kafka-consumer-).*$$'
+    depends_on:
+      - kafka
+      - zookeeper
+    networks:
+      - default
+      - lab
+    expose:
+      - 8000
+    restart: on-failure
+
+networks:
+  default:
+    name: dab_apps
+  lab:
+    external:
+      name: lab


### PR DESCRIPTION
Ingests into influxdb via telegraf by default but has no dashboard afaik