### PR TITLE
Fix discovering dependencies for apps with hyphenated names

### DIFF
--- a/app/lib/docker.sh
+++ b/app/lib/docker.sh
@@ -55,7 +55,7 @@ get_app_dependencies() {
 	file="$DAB/docker/docker-compose.$app.yml"
 	[ -f "$file" ] || return 0
 
-	val="$(yq -r ".services.$app.depends_on" <"$file")"
+	val="$(yq -r ".services[\"$app\"].depends_on" <"$file")"
 	[ "$val" != "null" ] || return 0
 
 	echo "$val" | sed -e '1d' -e '$d' | cut -d '"' -f 2
@@ -65,7 +65,7 @@ get_app_label_value() {
 	app="$1"
 	label="$2"
 	default="${3:-}"
-	val="$(yq -r ".services.$app.labels.$label" <"$DAB/docker/docker-compose.$app.yml")"
+	val="$(yq -r ".services[\"$app\"].labels.$label" <"$DAB/docker/docker-compose.$app.yml")"
 	[ "$val" != "null" ] || val="$default"
 	[ -z "$val" ] || echo "$val"
 }


### PR DESCRIPTION
Fixes bug introduced in #278 for apps with hypenated names such as `kafka-topics-ui`