### PR TITLE
Disable elasticsearch authentication

### DIFF
--- a/app/docker/docker-compose.elasticsearch.yml
+++ b/app/docker/docker-compose.elasticsearch.yml
@@ -11,6 +11,7 @@ services:
     environment:
       discovery.type: 'single-node'
       bootstrap.memory_lock: 'true'
+      xpack.security.enabled: 'false'
       ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     healthcheck:
       test: 'curl -fsSL "http://localhost:9200/_cat/health?h=status" | grep green'


### PR DESCRIPTION
Seems to have auth off on 6.0 by default but on for 5.6 and lower