### PR TITLE
Add url column to repo list output

### DIFF
--- a/app/subcommands/repo/list
+++ b/app/subcommands/repo/list
@@ -11,7 +11,7 @@ dab repo fetch
 repo_data=''
 repo_row() {
 	repo_data="$repo_data
-$1:$2:$3:$4"
+$1\`$2\`$3\`$4\`$5"
 }
 
 set +f
@@ -39,7 +39,9 @@ for dir in "$DAB_CONF_PATH"/repo/*; do
 		fi
 	fi
 
-	repo_row "$repo" "$status" "${clean:-}" "${uptodate:-}"
+	url="$(dab config get repo/"$repo"/website)"
+
+	repo_row "$repo" "$status" "${clean:-}" "${uptodate:-}" "$url"
 done
 set -f
 
@@ -49,4 +51,4 @@ colorize_table() {
 		-e 's/✗/\\e[0;31m✗\\e[0m/g'
 }
 
-printf '%b\n' "$(echo "$repo_data" | column -s':' -o' | ' -t -N REPO,STATUS,CLEAN,UPTODATE -R status | colorize_table)"
+printf '%b\n' "$(echo "$repo_data" | column -s'\`' -o' | ' -t -N REPO,STATUS,CLEAN,UPTODATE,URL -R status | colorize_table)"

--- a/tests/features/repo.feature
+++ b/tests/features/repo.feature
@@ -110,3 +110,14 @@ Feature: Subcommand: dab repo
 
 		Then the directory "~/dab/dotfiles9/.git/" should exist
 		And the directory "~/dab/dotfiles10/.git/" should exist
+
+	Scenario: Can list repositories url
+		Given I successfully run `dab repo add dotfiles11 https://github.com/Nekroze/dotfiles.git`
+		And I successfully run `dab repo add dotfiles12 https://github.com/Nekroze/dotfiles.git`
+		And I successfully run `dab config add repo/dotfiles12/website www.dotfiles12.test.website`
+
+		When I successfully run `dab repo list`
+
+		Then the output should match /^REPO\s*|.*|\s*URL$/
+		And the output should match /^dotfiles11\s*|.*|\s*$/
+		And the output should match /^dotfiles12\s*|.*|\swww\.dotfiles12\.test\.website$/


### PR DESCRIPTION
Adds an extra column to the `repo  list` output that uses the repos url or a
custom url (config key: alt_url) if defined.

feature request from #265