### PR TITLE
Proxy subcommand

### DIFF
--- a/app/docker/docker-compose.mitmproxy.yml
+++ b/app/docker/docker-compose.mitmproxy.yml
@@ -9,6 +9,11 @@ services:
       description: 'HTTP debuging swiss-army knife, connect and go to http://mitm.it to load certs'
       com.centurylinklabs.watchtower.enable: 'true'
     restart: on-failure
+    healthcheck:
+      test: 'wget --quiet --tries=1 --spider http://localhost:8081'
+      interval: 10s
+      timeout: 5s
+      retries: 3
     volumes:
       - "$HOME/.mitmproxy:/home/mitmproxy/.mitmproxy"
     networks:

--- a/app/lib/docker.sh
+++ b/app/lib/docker.sh
@@ -21,7 +21,7 @@ dpose() {
 	shift
 	env COMPOSE_PROJECT_NAME=dab \
 		COMPOSE_FILE="$(get_docker_compose_files_for_app "$app")" \
-		docker-compose --project-directory "$DAB/docker" "$@"
+		docker-compose --project-directory "$DAB/docker" "$@" 3>&1 1>&2 2>&3 | sed '/If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up/d'
 	[ "${DAB_PROFILING:-false}" = 'false' ] || echo "[PROFILE] $(date '+%s.%N') [STOP] dpose $*"
 }
 

--- a/app/lib/hindsight.sh
+++ b/app/lib/hindsight.sh
@@ -5,10 +5,6 @@ set -euf
 # shellcheck disable=SC1090
 . "$DAB/lib/output.sh"
 
-echo_red() {
-	echo_color "$COLOR_RED" "$@" 1>&2
-}
-
 captain_hindsight() {
 	# shellcheck disable=SC2181
 	[ $? -ne 0 ] || return 0           # Exit status code was 0
@@ -17,25 +13,29 @@ captain_hindsight() {
 	cmdline="dab $*"
 
 	echo
-	echo_red "I'm sorry, it looks like the command '$cmdline' failed."
+	error "I'm sorry, it looks like the command '$cmdline' failed."
 
 	case "$cmdline" in
 	'dab apps'*)
-		echo_red "If the app is misbehaving perhaps try 'dab apps update <APP_NAME>' and start it up again"
-		echo_red "If you are unsure what the app is doing try 'dab apps logs <APP_NAME>'"
-		echo_red "If the app has some bad data perhaps try 'dab apps destroy <APP_NAME>' and start it up again"
+		error "If the app is misbehaving perhaps try 'dab apps update <APP_NAME>' and start it up again"
+		error "If you are unsure what the app is doing try 'dab apps logs <APP_NAME>'"
+		error "If the app has some bad data perhaps try 'dab apps destroy <APP_NAME>' and start it up again"
 		;;
 	'dab pki issue'* | 'dab pki renew'*)
-		echo_red "If the pki is misbehaving perhaps try 'dab pki ready'"
-		echo_red "If the pki has some bad data perhaps try 'dab pki destroy'"
+		error "If the pki is misbehaving perhaps try 'dab pki ready'"
+		error "If the pki has some bad data perhaps try 'dab pki destroy'"
 		;;
 	'dab pki ready'* | 'dab pki up'*)
-		echo_red "If the pki has some bad data perhaps try 'dab pki destroy'"
+		error "If the pki has some bad data perhaps try 'dab pki destroy'"
 		;;
 	'dab config'*)
-		echo_red "If the config key needs to be wiped, then give no value to 'dab config set'"
+		error "If the config key needs to be wiped, then give no value to 'dab config set'"
+		;;
+	'dab network proxy'*)
+		error "To fix mitmproxy certificates you may try 'dab pki destroy' to wipe them"
+		error "If mitmproxy is having trouble starting, check its logs with 'dab apps logs mitmproxy'"
 		;;
 	esac
 
-	echo_red 'If you believe this to due to a problem with Dab please file a bug report at https://github.com/Nekroze/dab/issues/new?template=bug_report.md'
+	error 'If you believe this to due to a problem with Dab please file a bug report at https://github.com/Nekroze/dab/issues/new?template=bug_report.md'
 }

--- a/app/subcommands/network/proxy
+++ b/app/subcommands/network/proxy
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Description: Start a proxy server providing clients access to the lab network
+# vim: ft=sh ts=4 sw=4 sts=4 noet
+set -euf
+
+# shellcheck disable=SC1090
+. "$DAB/lib/docker.sh"
+
+# Ensure the pki is ready
+dab pki ready
+
+# Ensure the pki ready setup the mitmproxy certs
+ready='true'
+if ! diff "$DAB_CONF_PATH/pki/ca/bundle" ~/.mitmproxy/mitmproxy-ca.pem; then
+	error 'The contents of ~/.mitmproxy/mitmproxy-ca.pem must match the config key pki/ca/bundle'
+	ready='false'
+fi
+if ! diff "$DAB_CONF_PATH/pki/ca/certificate" ~/.mitmproxy/mitmproxy-ca-cert.pem; then
+	error 'The contents of ~/.mitmproxy/mitmproxy-ca-cert.pem must match the config key pki/ca/certificate'
+	ready='false'
+fi
+"$ready" || fatality 'Your machine is not ready to start the proxy!'
+
+# Start mitmproxy and ensure it is healthy
+dpose 'mitmproxy' up --detach || fatality 'Failed to start mitmproxy app!'
+inform 'Waiting for mitmproxy to be healthy'
+ishmael healthy --wait 30 dab_mitmproxy
+
+# Display information on using the proxy
+addresses="$(ishmael address dab_mitmproxy)"
+echo
+inform "Please point your HTTP proxy client at http://$(echo "$addresses" | grep ':8080')"
+inform "To view/replay requests via the dashboard go to http://$(echo "$addresses" | grep ':8081')"
+inform "To expose this proxy to the internet start the preconfigured serveo app with 'dab apps start serveo'"

--- a/completion/main.go
+++ b/completion/main.go
@@ -16,6 +16,7 @@ var dab = complete.Command{
 			Sub: complete.Commands{
 				"destroy": {}, "delete": {},
 				"shell": {}, "sh": {}, "cmd": {},
+				"proxy": {},
 			},
 		},
 		"pki": {

--- a/tests/features/network.feature
+++ b/tests/features/network.feature
@@ -30,3 +30,10 @@ Feature: Subcommand: dab network
 		When I run `dab network shell ls /`
 
 		Then it should pass with "bin"
+
+	Scenario: Provides an HTTP proxy into the network
+		When I run `dab network proxy`
+
+		Then the exit status should be 0
+		And the output should contain ":8080"
+		And the output should contain ":8081"


### PR DESCRIPTION
Add new `dab network proxy` subcommand that asserts the pki is configured correctly for mitmproxy then starts mitmproxy and gives tips on starting to use it.