### PR TITLE
Ansible env var passthrough and postgres configurability

### DIFF
--- a/app/docker/Dockerfile.postgres
+++ b/app/docker/Dockerfile.postgres
@@ -1,0 +1,6 @@
+ARG POSTGRES_TAG=latest
+FROM "postgres:$POSTGRES_TAG"
+
+ARG LOCALE="en_US"
+RUN localedef -i "${LOCALE}" -c -f UTF-8 -A /usr/share/locale/locale.alias "${LOCALE}.UTF-8"
+ENV LANG ="${LOCALE}"

--- a/app/docker/docker-compose.ansible.yml
+++ b/app/docker/docker-compose.ansible.yml
@@ -13,6 +13,10 @@ services:
       description: 'Automated configuration management'
     environment:
       - HOME
+      - DAB_GID
+      - DAB_UID
+      - DAB_USER
+      - DAB_DOCKER_GID
     volumes:
       - "$HOME:$HOME"
       - "$HOST_PWD:$HOST_PWD"

--- a/app/docker/docker-compose.postgres.yml
+++ b/app/docker/docker-compose.postgres.yml
@@ -4,7 +4,12 @@ services:
 
   postgres:
     container_name: dab_postgres
-    image: "postgres:${DAB_APPS_POSTGRES_TAG:-alpine}"
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres
+      args:
+        - "POSTGRES_TAG=${DAB_APPS_POSTGRES_TAG:-latest}"
+        - "LOCALE=${DAB_APPS_POSTGRES_LOCALE:-en_US}"
     labels:
       description: 'Object-relational database management system'
       exposing: 'tcp'
@@ -14,6 +19,8 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - postgres:/var/lib/postgresql/data/pgdata
+      - "$DAB_CONF_PATH/apps/postgres/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:ro"
+    command: "${DAB_APPS_POSTGRES_FLAGS:-}"
     networks:
       - default
       - lab


### PR DESCRIPTION
## Change Description

Postgres can now be customized via flags (`-c` can set any config file value) and its locale can be changed with env vars (requires a `dab apps update postgres`) and starts a new config namespace for apps bind mounts to expose the provisioning directory.

## Relevant Issue(s)

- Increment of #305
- Closes #308
