### PR TITLE
Fix `dab group repo` to add extra entrypoint args

### DIFF
--- a/app/subcommands/group/repos
+++ b/app/subcommands/group/repos
@@ -9,5 +9,8 @@ set -euf
 
 [ -n "${1:-}" ] || fatality 'must provide a group name to add too'
 [ -n "${2:-}" ] || fatality 'must provide a repo name to add as a dependency'
-[ -n "${3:-}" ] || fatality 'must provide a entrypoiny name to be run'
-config_add "group/$1/repos" "$2" "$3"
+[ -n "${3:-}" ] || fatality 'must provide a entrypoint name to be run'
+group_name="$1"
+shift
+
+config_add "group/${group_name}/repos" "$@"

--- a/tests/features/group.feature
+++ b/tests/features/group.feature
@@ -56,3 +56,18 @@ Feature: Subcommand: dab group
 		Executing seven entrypoint deploy
 		"""
 		And I successfully run `docker ps`
+
+	Scenario: Can add entrypoint to group with aditional arguments
+		Given I successfully run `dab repo add eight https://github.com/Nekroze/dotfiles.git`
+		And I run `dab repo entrypoint create eight start`
+
+		When I run `dab group repos args eight start --test-arg -D 1`
+
+		Then it should pass with "contains 1 value(s)"
+
+		When I run `dab group start args`
+
+		Then it should pass with:
+		"""
+		Executing eight entrypoint start --test-arg -D 1
+		"""


### PR DESCRIPTION
Fix the `dab group repo` command to accept adding extra arguments to a
repos entrypoint.

## Change Description

Bug fix.

## Relevant Issue(s)

- Fixes #306
