### PR TITLE
Better sudo support increment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ If you do not need to build the docker image yourself and just want to use dab, 
 
 It is recommended you add the directory containing the [dab script][1] to your shell's `PATH` environment variable.
 
+If you want to execute `dab` with `sudo` and retain set environmental variables, you can use the following to execute dab:
+```bash
+ $ sudo -E dab --help
+```
+
 ## Stable Updates Stream
 
 The latest image is built off of the ever changing master branch. While all efforts are made to keep the UI and behaviour stable, you may wish to use the `stable` docker tag (and thus git branch) which receives periodic merges from the master branch.

--- a/app/subcommands/tip
+++ b/app/subcommands/tip
@@ -45,6 +45,7 @@ Any .log files placed in the docker volume named dab_logs can be ingested for di
 You can use docker-compose-gen in your entrypoint scripts to easily interface with Dab docker objects
 You can use multitail in your entrypoint scripts to display your logs, and in style
 If you want to dig into the messages on Dab's Kafka topics, try 'dab apps start kafka-topics-ui' for a handy web interface
+If you wish to preserve any environmental variables while using dab with sudo, you can run dab like so 'sudo -E dab foo bar'
 "
 
 get_tip_corpus() {

--- a/dab
+++ b/dab
@@ -25,14 +25,13 @@ fi
 # Pass current working directory through to a consistent location.
 dArg -e "HOST_PWD=$PWD" -v "$PWD:/pwd"
 
-# Pass the calling user in as DAB_USER
-export DAB_USER="${USER:-user}"
-
-# UID and GID passthrough/customization.  This will prevent most common docker
+# UID and GID passthrough/customization. This will prevent most common docker
 # issues with volume mounting directories owned by or running as a different
 # user. Also allows customizable permissions if you want to make a user group
 # for dab on your machine to restrict its access more granularly, and provide
 # security by not running as root.
+[ -z "${SUDO_UID:-}" ] || DAB_UID="$SUDO_UID"
+[ -z "${SUDO_GID:-}" ] || DAB_GID="$SUDO_GID"
 # shellcheck disable=SC2039
 if [ -z "${DAB_UID:-}" ]; then
 	if [ -n "${UID:-}" ]; then
@@ -49,17 +48,28 @@ if [ -z "${DAB_GID:-}" ]; then
 	fi
 fi
 export DAB_UID DAB_GID
+# Pass the calling user in as DAB_USER
+export DAB_USER="${SUDO_USER:-${USER:-user}}"
 dArg \
 	--user "$DAB_UID:$DAB_GID" \
-	-e USER="${USER:-user}"
+	-e USER="$DAB_USER"
 
-# Home passthrough.
+# Home passthrough. Detects sudo usage and attempts to mount to the lower
+# privileged user's home.
+if [ -n "${SUDO_USER:-}" ]; then
+	if [ -d "/home/$SUDO_USER" ]; then
+		HOME="/home/$SUDO_USER"
+	elif [ -d "/Users/$SUDO_USER" ]; then
+		HOME="/Users/$SUDO_USER"
+	fi
+fi
+
 dArg \
 	-v "$HOME:$HOME" \
 	-e "HOME=$HOME"
 ##OSX does not have /home
-if echo "$HOME" | grep -q '/home'; then
-	dArg -v "$HOME:/home/$USER"
+if echo "$HOME" | grep -qv '/home'; then
+	dArg -v "$HOME:/home/$DAB_USER"
 fi
 
 # Docker group lists access if it exists on the host.


### PR DESCRIPTION
Increment to - Allow for users without docker access that use sudo to still mount their home

## Change Description

Increments @Nekroze's - "Allow for users without docker access that use sudo to still mount their home" commit. Specificity this pull request includes that commit and additions to the README.md and app/subcommands/tip files, to notify users that to retain any environmental variables while using `sudo`, that they should run dab with:
```bash
 $ sudo -E dab --help
``` 
