### PR TITLE
Fix dab not cloning git submodules

### DIFF
--- a/app/subcommands/repo/clone
+++ b/app/subcommands/repo/clone
@@ -13,7 +13,7 @@ for repo in "$@"; do
 	url="$(config_get "repo/$repo/url")"
 	[ -n "$url" ] || fatality "url for repo $repo is unknown"
 
-	[ -d "$DAB_REPO_PATH/$repo" ] || git clone "$url" "$DAB_REPO_PATH/$repo"
+	[ -d "$DAB_REPO_PATH/$repo" ] || git clone --recursive "$url" "$DAB_REPO_PATH/$repo"
 
 	if [ -d "$DAB_CONF_PATH/repo/$repo/remotes/" ]; then
 		cd "$DAB_REPO_PATH/$repo"

--- a/tests/features/repo.feature
+++ b/tests/features/repo.feature
@@ -140,3 +140,14 @@ Feature: Subcommand: dab repo
 		[remote "upstream"]
 			url = 1b59f40e-75c8-4c0c-bede-f5462ae15373
 		"""
+
+	Scenario: Can clone a repository and any submodules
+		Given the directory "~/dab/dotfiles14/.git/" should not exist
+
+		When I successfully run `dab repo add dotfiles14 https://github.com/Nekroze/dotfiles.git`
+
+		Then the directory "~/dab/dotfiles14/.git" should exist
+
+		And the directory "~/dab/dotfiles14/.git/modules/dotfiles" should exist
+
+		And the file "~/dab/dotfiles14/dotfiles/.git" should exist


### PR DESCRIPTION
Fix `dab repo clone` to clone git submodules

## Change Description

Fixes the `dab repo clone` command to clone the desired repository and
any submodules of that repository.

## Relevant Issue(s)

- Fixes #313
