### PR TITLE
Add repo list filter

### DIFF
--- a/app/subcommands/repo/list
+++ b/app/subcommands/repo/list
@@ -3,6 +3,8 @@
 # vim: ft=sh ts=4 sw=4 sts=4 noet
 set -euf
 
+filter="${1:-all}"
+
 # shellcheck disable=SC1090
 . "$DAB/lib/update.sh"
 
@@ -41,7 +43,13 @@ for dir in "$DAB_CONF_PATH"/repo/*; do
 
 	url="$(dab config get repo/"$repo"/website)"
 
-	repo_row "$repo" "$status" "${clean:-}" "${uptodate:-}" "$url"
+	if [ "$filter" = "all" ]; then
+		repo_row "$repo" "$status" "${clean:-}" "${uptodate:-}" "$url"
+	fi
+
+	if [ "$filter" = "$status" ]; then
+		repo_row "$repo" "$status" "${clean:-}" "${uptodate:-}" "$url"
+	fi
 done
 set -f
 

--- a/tests/features/repo.feature
+++ b/tests/features/repo.feature
@@ -50,6 +50,19 @@ Feature: Subcommand: dab repo
 		And the output should match /^dotfiles3\s*|\s*not downloaded/
 		And the output should match /^dotfiles4\s*|\s*downloaded/
 
+	Scenario: Can filter listed repositories
+		Given a file named "~/.config/dab/repo/dotfiles3/url" with:
+		"""
+		https://github.com/Nekroze/dotfiles.git
+		"""
+		And the directory "~/dab/dotfiles3/.git/" should not exist
+		And I successfully run `dab repo add dotfiles4 https://github.com/Nekroze/dotfiles.git`
+
+		When I successfully run `dab repo list downloaded`
+
+		Then the output should match /^REPO\s*|\s*STATUS/
+		And the output should match /^dotfiles4\s*|\s*downloaded/
+
 	Scenario: Can set entrypoint to script
 		Given I successfully run `dab repo add dotfiles4 https://github.com/Nekroze/dotfiles.git`
 


### PR DESCRIPTION
## Change Description
Add an optional filter param to the `dab repo list` sub-command.
- If none is provided it will show all
- Other accepted inputs are "downloaded" and "not downloaded"

