### PR TITLE
Add network recreate and its aliases to shell completion

### DIFF
--- a/completion/main.go
+++ b/completion/main.go
@@ -16,6 +16,7 @@ var dab = complete.Command{
 			Sub: complete.Commands{
 				"destroy": {}, "delete": {},
 				"shell": {}, "sh": {}, "cmd": {},
+				"recreate": {}, "up": {}, "rebuild": {},
 				"proxy": {},
 			},
 		},


### PR DESCRIPTION
## Change Description

`dab network recreate` and its aliases are now in shell completion.
