### PR TITLE
Automated PR to stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,24 @@ notify:
 
 workflows:
   version: 2
+
   'Review & Test':
     jobs:
       - 'Danger Automated Code Review'
       - 'Feature Testing'
       - 'UX Regression Testing'
+
+  'Periodic Stable Branch Updates':
+    jobs:
+      - 'Request Stable Branch Update'
+
+    triggers:
+      - schedule:
+          cron: "0 0 * * 1,3"
+          filters:
+            branches:
+              only:
+                - master
 
 jobs:
   'Danger Automated Code Review':
@@ -21,7 +34,7 @@ jobs:
       - checkout
 
       - run:
-          name: Danger
+          name: danger
           command: ./scripts/danger.sh
 
 
@@ -103,3 +116,14 @@ jobs:
 
       - store_test_results:
           path: /tmp/dab/test_results
+
+  'Request Stable Branch Update':
+    machine: true
+    steps:
+
+      - checkout
+
+      - run:
+          name: request
+          command: ./scripts/request-stable-update.sh
+

--- a/scripts/request-stable-update.sh
+++ b/scripts/request-stable-update.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# vim: ft=sh ts=4 sw=4 sts=4 noet
+set -euf
+
+curl \
+	-X POST \
+	-u "$PR_GITHUB_API_USER:$PR_GITHUB_API_TOKEN" \
+	-d '{"title": "Update Stable Branch","head": "master","base": "stable"}' \
+	https://api.github.com/repos/Nekroze/dab/pulls


### PR DESCRIPTION
## Change Description

Adds a script that can request the `stable` branch be updated from the `master` branch and schedule it to run in CircleCI at midnight on Monday and Wednesday of each week.

## Relevant Issue(s)

- Implements #328 
