### PR TITLE
Update golangci-lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ FROM golang:latest AS completion
 WORKDIR $GOPATH/src/app/completion
 
 # Install golangci-lint
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.12.2
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.15.0
 ENV GO111MODULE=on
 
 # Test, lint, and build the shell completion binary.


### PR DESCRIPTION

## Change Description

Updates golangci-lint from v1.12.2 to a newer version, to allow for the building of dab.

## Relevant Issue(s)

- Fixes #340