### PR TITLE
Make dab apps use safe port maps instead of exposures for UIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -
 
 COPY --from=koalaman/shellcheck-alpine:stable  /bin/shellcheck /usr/bin/shellcheck
 COPY --from=completion /usr/bin/dab-completion* /usr/bin/
-COPY --from=nekroze/ishmael:v1.2.2 /app /usr/bin/ishmael
+COPY --from=nekroze/ishmael:v1.3.0 /app /usr/bin/ishmael
 COPY --from=nekroze/docker-compose-gen:latest /app /usr/bin/docker-compose-gen
 
 

--- a/app/docker/docker-compose.adminer.yml
+++ b/app/docker/docker-compose.adminer.yml
@@ -16,6 +16,8 @@ services:
       ADMINER_DEFAULT_SERVER: mysql
     expose:
       - 8080
+    ports:
+      - 8080
 
 networks:
   default:

--- a/app/docker/docker-compose.burrow.yml
+++ b/app/docker/docker-compose.burrow.yml
@@ -23,6 +23,8 @@ services:
       - lab
     expose:
       - 8000
+    ports:
+      - 8000
     restart: on-failure
 
 networks:

--- a/app/docker/docker-compose.chronograf.yml
+++ b/app/docker/docker-compose.chronograf.yml
@@ -22,6 +22,8 @@ services:
       LOG_LEVEL: error
     expose:
       - 8888
+    ports:
+      - 8888
     healthcheck:
       test: 'wget --spider http://localhost:8888/ || exit 1'
       interval: 1m

--- a/app/docker/docker-compose.consul.yml
+++ b/app/docker/docker-compose.consul.yml
@@ -13,6 +13,8 @@ services:
       - consul:/consul/data
     expose:
       - 8500
+    ports:
+      - 8500
     environment:
       CONSUL_LOCAL_CONFIG: >
         {

--- a/app/docker/docker-compose.cyberchef.yml
+++ b/app/docker/docker-compose.cyberchef.yml
@@ -13,6 +13,8 @@ services:
       description: 'The Cyber Swiss Army Knife'
     expose:
       - 80
+    ports:
+      - 80
     healthcheck:
       test: 'wget --spider http://localhost || exit 1'
       interval: 1m

--- a/app/docker/docker-compose.gaia.yml
+++ b/app/docker/docker-compose.gaia.yml
@@ -16,6 +16,8 @@ services:
       - gaia:/data
     expose:
       - 8080
+    ports:
+      - 8080
     tmpfs:
       - /tmp
 

--- a/app/docker/docker-compose.grafana.yml
+++ b/app/docker/docker-compose.grafana.yml
@@ -18,6 +18,8 @@ services:
       GF_AUTH_ANONYMOUS_ENABLED: 'true'
     expose:
       - 3000
+    ports:
+      - 3000
     healthcheck:
       test: 'wget --spider http://localhost:3000/api || exit 1'
       interval: 1m

--- a/app/docker/docker-compose.kafka-rest.yml
+++ b/app/docker/docker-compose.kafka-rest.yml
@@ -20,6 +20,8 @@ services:
       - zookeeper
     expose:
       - 8082
+    ports:
+      - 8082
     restart: on-failure
 
 networks:

--- a/app/docker/docker-compose.kafka-topics-ui.yml
+++ b/app/docker/docker-compose.kafka-topics-ui.yml
@@ -17,6 +17,8 @@ services:
       - kafka-rest
     expose:
       - 8000
+    ports:
+      - 8000
     restart: on-failure
     tmpfs:
       - /tmp

--- a/app/docker/docker-compose.kapacitor.yml
+++ b/app/docker/docker-compose.kapacitor.yml
@@ -16,6 +16,8 @@ services:
       LOG_LEVEL: error
     expose:
       - 9092
+    ports:
+      - 9092
     volumes:
       - kapacitor:/var/lib/kapacitor
     healthcheck:

--- a/app/docker/docker-compose.kibana.yml
+++ b/app/docker/docker-compose.kibana.yml
@@ -13,6 +13,8 @@ services:
       - elasticsearch
     expose:
       - 5601
+    ports:
+      - 5601
 
 networks:
   default:

--- a/app/docker/docker-compose.minio.yml
+++ b/app/docker/docker-compose.minio.yml
@@ -18,6 +18,8 @@ services:
       - minio:/data
     expose:
       - 9000
+    ports:
+      - 9000
     restart: on-failure
     tmpfs:
       - /tmp

--- a/app/docker/docker-compose.mitmproxy.yml
+++ b/app/docker/docker-compose.mitmproxy.yml
@@ -21,6 +21,9 @@ services:
     expose:
       - 8080
       - 8081
+    ports:
+      - 8080
+      - 8081
     command: mitmweb --web-iface 0.0.0.0 --ssl-insecure
     tmpfs:
       - /tmp

--- a/app/docker/docker-compose.ntopng.yml
+++ b/app/docker/docker-compose.ntopng.yml
@@ -14,6 +14,8 @@ services:
     network_mode: host
     expose:
       - 3000
+    ports:
+      - 3000
     restart: on-failure
     command: --redis localhost:16379
     tmpfs:

--- a/app/docker/docker-compose.openvas.yml
+++ b/app/docker/docker-compose.openvas.yml
@@ -14,7 +14,9 @@ services:
     restart: on-failure
     network_mode: host
     expose:
-        - 443
+      - 443
+    ports:
+      - 443
     environment:
       PUBLIC_HOSTNAME: localhost
       OV_PASSWORD: "${DAB_APPS_OPENVAS_PASSWORD:-admin}"

--- a/app/docker/docker-compose.pgweb.yml
+++ b/app/docker/docker-compose.pgweb.yml
@@ -11,6 +11,8 @@ services:
     restart: on-failure
     expose:
       - 8081
+    ports:
+      - 8081
     environment:
       DATABASE_URL: 'postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable'
     depends_on:

--- a/app/docker/docker-compose.portainer.yml
+++ b/app/docker/docker-compose.portainer.yml
@@ -10,6 +10,8 @@ services:
       com.centurylinklabs.watchtower.enable: 'true'
     expose:
       - 9000
+    ports:
+      - 9000
     command: -H unix:///var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/app/docker/docker-compose.selenium.yml
+++ b/app/docker/docker-compose.selenium.yml
@@ -17,6 +17,8 @@ services:
     expose:
       - 4444
       - 5900
+    ports:
+      - 5900
     restart: on-failure
     tmpfs:
       - /tmp

--- a/app/docker/docker-compose.traefik.yml
+++ b/app/docker/docker-compose.traefik.yml
@@ -20,6 +20,8 @@ services:
       - --tracing.zipkin.httpendpoint=http://telegraf:9411/api/v1/spans
     expose:
       - 80
+    ports:
+      - 80
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     healthcheck:

--- a/app/docker/docker-compose.vyne.yml
+++ b/app/docker/docker-compose.vyne.yml
@@ -11,6 +11,8 @@ services:
     restart: on-failure
     expose:
       - 9022
+    ports:
+      - 9022
     environment:
       PROFILE: 'embedded-discovery'
     tmpfs:

--- a/app/subcommands/apps/address
+++ b/app/subcommands/apps/address
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Description: Displays the address of any apps exposed by the app
+# Description: Displays the addresses of any exposed/published ports
 # Usage: <APP_NAME>
 # vim: ft=sh ts=4 sw=4 sts=4 noet
 set -eu

--- a/app/subcommands/apps/start
+++ b/app/subcommands/apps/start
@@ -12,4 +12,4 @@ set -eu
 [ -n "${1:-}" ] || fatality 'must provide an app name'
 
 dpose "$1" up --detach "$@"
-dab apps address "$1"
+dab apps address "$1" | grep -E ':3[0-9]+$' || true


### PR DESCRIPTION
## Change Description

This changes to the latest version of ishmael which displays port maps and uses it for all dockerized app user interfaces. Incidently this also fixes `dab apps` usage issues on OSX.

## Relevant Issue(s)

- Closes #351