### PR TITLE
Share hosts /tmp with sam app for local lambda invocation

### DIFF
--- a/app/docker/docker-compose.sam.yml
+++ b/app/docker/docker-compose.sam.yml
@@ -14,6 +14,7 @@ services:
     user: "$DAB_UID:$DAB_DOCKER_GID"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
       - "$HOME:$HOME"
       - "$HOST_PWD:$HOST_PWD"
     working_dir: "$HOST_PWD"


### PR DESCRIPTION
## Change Description

Passes `/tmp` from host into the Sam app to try fix lambda invocation..

## Relevant Issue(s)

- Fixes #374 
