### PR TITLE
Allow setting tip when adding a repo

### DIFF
--- a/app/subcommands/repo/add
+++ b/app/subcommands/repo/add
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Description: Add a repo by giving a name and the url
-# Usage: <REPO_NAME> <GIT_URL>
+# Description: Add a repo by giving a name and the url, optionally using the given tip
+# Usage: <REPO_NAME> <GIT_URL> [<TIP>]
 # vim: ft=sh ts=4 sw=4 sts=4 noet
 set -eu
 
@@ -9,6 +9,8 @@ set -eu
 
 [ -n "${1:-}" ] || fatality 'must provide a repo name as the first parameter'
 [ -n "${2:-}" ] || fatality 'must provide a repo url as the second parameter'
+[ -z "${3:-}" ] || config_set "repo/$1/tip" "$3"
+
 config_set "repo/$1/url" "$2"
 
 dab repo clone "$1"

--- a/tests/features/repo.feature
+++ b/tests/features/repo.feature
@@ -195,3 +195,11 @@ Feature: Subcommand: dab repo
 		When I successfully run `sh -c "cd ~/dab/dotfiles20 && git rev-parse --short HEAD"`
 
 		Then the output should match /^ed0277d$/
+
+	Scenario: Repos can be registered with a tip
+
+		Given I successfully run `sh -c "dab repo add dotfiles21 https://github.com/Nekroze/dotfiles.git ed0277d >/dev/null"`
+
+		When I successfully run `sh -c "cd ~/dab/dotfiles21 && git rev-parse --short HEAD"`
+
+		Then the output should match /^ed0277d$/


### PR DESCRIPTION
## Change Description

Add optional third argument to `dab repo add` to accept the tip to use for the repo.

## Relevant Issue(s)

- Increment of #380
