### PR TITLE
Add support for global entrypoints

### DIFF
--- a/app/bin/recklessly
+++ b/app/bin/recklessly
@@ -1,0 +1,2 @@
+#!/bin/sh
+"$@" 2>/dev/null || true

--- a/app/subcommands/repo/entrypoint/create
+++ b/app/subcommands/repo/entrypoint/create
@@ -1,14 +1,19 @@
 #!/bin/sh
-# Description: Create an entrypoint (defaults to start) for the given repo
-# Usage: <REPO_NAME> [<ENTRYPOINT_NAME>]
+# Description: Create an entrypoint for the given repo or global if given none
+# Usage: [<REPO_NAME>] <ENTRYPOINT_NAME>
 # vim: ft=sh ts=4 sw=4 sts=4 noet
 set -eu
 
 # shellcheck source=app/lib/config.sh
 . "$DAB/lib/config.sh"
 
-[ -n "${1:-}" ] || fatality 'must provide a repo name'
-newpath="repo/$1/entrypoint/${2:-start}"
+[ -n "${1:-}" ] || fatality 'must provide at least an entrypoint name'
+
+if [ "$#" = 1 ]; then
+	newpath="repo/*/entrypoint/$1"
+else
+	newpath="repo/$1/entrypoint/$2"
+fi
 
 if [ ! -e "$DAB_CONF_PATH/$newpath" ]; then
 	config_set "$newpath" "$(cat "$DAB/default-entrypoint.sh")"

--- a/app/subcommands/repo/entrypoint/list
+++ b/app/subcommands/repo/entrypoint/list
@@ -9,4 +9,5 @@ set -eu
 # shellcheck source=app/lib/config.sh
 . "$DAB/lib/config.sh"
 
-carelessly dab config tree "repo/$1/entrypoint"
+recklessly dab config tree "repo/$1/entrypoint"
+recklessly dab config tree "repo/*/entrypoint"

--- a/app/subcommands/repo/entrypoint/run
+++ b/app/subcommands/repo/entrypoint/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Description: Execute an entrypoint for the given repo
-# Usage: <REPO_NAME> [<ENTRYPOINT_NAME>]
+# Usage: <REPO_NAME> <ENTRYPOINT_NAME>
 # vim: ft=sh ts=4 sw=4 sts=4 noet
 set -eu
 
@@ -21,9 +21,12 @@ inform "Executing $repo entrypoint $entry$suffix"
 
 entrypoint="$DAB_CONF_PATH/repo/$repo/entrypoint/$entry"
 if [ ! -x "$entrypoint" ]; then
-	warn "$entry is not an executable entrypoint shell script for $repo"
-	warn "You could write one to \$DAB_CONF_PATH/repo/$repo/entrypoint/$entry and make it executable with 'chmod +x'"
-	exit 0
+	entrypoint="$DAB_CONF_PATH/repo/*/entrypoint/$entry"
+	if [ ! -x "$entrypoint" ]; then
+		warn "$entry is not an executable entrypoint shell script for $repo"
+		warn "You could write one to \$DAB_CONF_PATH/repo/$repo/entrypoint/$entry and make it executable with 'chmod +x'"
+		exit 0
+	fi
 fi
 
 cd "$DAB_REPO_PATH/$repo"

--- a/tests/features/repo.feature
+++ b/tests/features/repo.feature
@@ -59,7 +59,7 @@ Feature: Subcommand: dab repo
 
 	Scenario: Can put any command in an entrypoint start script
 		Given I successfully run `dab repo add dotfiles5 https://github.com/Nekroze/dotfiles.git`
-		And I run `dab repo entrypoint create dotfiles5`
+		And I run `dab repo entrypoint create dotfiles5 start`
 		And I append to "~/.config/dab/repo/dotfiles5/entrypoint/start" with:
 		"""
 		echo FOOBAR
@@ -203,3 +203,26 @@ Feature: Subcommand: dab repo
 		When I successfully run `sh -c "cd ~/dab/dotfiles21 && git rev-parse --short HEAD"`
 
 		Then the output should match /^ed0277d$/
+
+	Scenario: Can create global entrypoints
+		Given I successfully run `dab repo add dotfiles22 https://github.com/Nekroze/dotfiles.git`
+
+		When I run `dab repo entrypoint create start`
+
+		Then it should pass with "repo/*/entrypoint/start"
+
+	Scenario: Can run global entrypoints for use on any repo
+		Given I successfully run `dab repo add dotfiles23 https://github.com/Nekroze/dotfiles.git`
+		And I run `dab repo entrypoint create foobar`
+		And I append to "~/.config/dab/repo/*/entrypoint/foobar" with:
+		"""
+		echo FOOBAR
+		"""
+
+		When I run `dab repo entrypoint list dotfiles23`
+
+		Then it should pass with "foobar"
+
+		When I run `dab repo entrypoint run dotfiles23 foobar`
+
+		Then it should pass with "FOOBAR"


### PR DESCRIPTION
## Change Description

Global entrypoints are defined once and can be run on any repo if the repo does not have an entrypoint of the same name to override.

## Relevant Issue(s)

- Closes #381