### PR TITLE
Ensure listed repos are valid before displaying

### DIFF
--- a/app/subcommands/repo/list
+++ b/app/subcommands/repo/list
@@ -16,6 +16,7 @@ $1\`$2\`$3"
 repos=$(ls "$DAB_CONF_PATH/repo/")
 
 for repo in $repos; do
+	[ -f "$DAB_CONF_PATH/repo/$repo/url" ] || continue
 	status='not cloned'
 	[ -d "$DAB_REPO_PATH/$repo" ] && status='cloned'
 


### PR DESCRIPTION
## Change Description

Solves an issue with invalid config items being displayed as repos, adds a small validation to `dab repo list` to remedy.

## Relevant Issue(s)

- Fixes #394
