### PR TITLE
Set DAB_CURRENT_REPO to the current repo in entrypoints

### DIFF
--- a/app/subcommands/repo/entrypoint/run
+++ b/app/subcommands/repo/entrypoint/run
@@ -19,6 +19,8 @@ suffix="$*"
 [ -n "$suffix" ] && suffix=" $suffix"
 inform "Executing $repo entrypoint $entry$suffix"
 
+export DAB_CURRENT_REPO=$repo
+
 entrypoint="$DAB_CONF_PATH/repo/$repo/entrypoint/$entry"
 if [ ! -x "$entrypoint" ]; then
 	entrypoint="$DAB_CONF_PATH/repo/*/entrypoint/$entry"


### PR DESCRIPTION
## Change Description

This allows global entrypoints to know what repo they were run on
without inspecting pwd.

## Relevant Issue(s)

- Relates to #381 
