### PR TITLE
Fix group start command

### DIFF
--- a/app/subcommands/group/run
+++ b/app/subcommands/group/run
@@ -12,10 +12,7 @@ run_with_dependencies() {
 	configkey="$2"
 	configpath="$(config_path "$configkey")"
 	[ -f "$configpath" ] || return 0
-	while read -r dep; do
-		# shellcheck disable=SC2086
-		$depcmd $dep
-	done <"$configpath"
+	xargs -I{} sh -c "$depcmd {}" <"$configpath"
 }
 
 run_with_dependencies 'dab group start' "group/$group_name/groups"


### PR DESCRIPTION
Reading repo and groups in a while loop can result in broken group
configs if any of the repo apps read from stdin and so delete all
subsequent repos or groups
