### PR TITLE
Add MailHog application

### DIFF
--- a/app/docker/docker-compose.mailhog.yml
+++ b/app/docker/docker-compose.mailhog.yml
@@ -1,0 +1,37 @@
+version: '3.5'
+
+services:
+
+  mailhog:
+    container_name: dab_mailhog
+    image: "mailhog/mailhog:${DAB_APPS_MAILHOG_TAG:-latest}"
+    restart: on-failure
+    labels:
+      description: 'MailHog runs a super simple SMTP server which catches any message sent to it to display in a web interface'
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - default
+      - lab
+    ports:
+      - 1025
+      - 8025
+    env_file:
+      - /tmp/denvmux/mailhog.env
+    environment:
+      MH_CORS_ORIGIN: "${DAB_APPS_MAILHOG_CORS_ORIGIN:-}"
+      MH_HOSTNAME: "${DAB_APPS_MAILHOG_HOSTNAME:-mailhog.example}"
+      MH_API_BIND_ADDR: "${DAB_APPS_MAILHOG_API_BIND_ADDR:-0.0.0.0:8025}"
+      MH_UI_BIND_ADDR: "${DAB_APPS_MAILHOG_UI_BIND_ADDR:-0.0.0.0:8025}"
+      MH_MAILDIR_PATH: "${DAB_APPS_MAILHOG_MAILDIR_PATH:-}"
+      MH_SMTP_BIND_ADDR: "${DAB_APPS_MAILHOG_SMTP_BIND_ADDR:-0.0.0.0:1025}"
+      MH_STORAGE: "${DAB_APPS_MAILHOG_STORAGE:-memory}"
+      MH_OUTGOING_SMTP: "${DAB_APPS_MAILHOG_OUTGOING_SMTP:-}"
+      MH_UI_WEB_PATH: "${DAB_APPS_MAILHOG_UI_WEB_PATH:-}"
+      MH_AUTH_FILE: "${DAB_APPS_MAILHOG_AUTH_FILE:-}"
+
+networks:
+  default:
+    name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/tests/features/apps.feature
+++ b/tests/features/apps.feature
@@ -87,6 +87,7 @@ Feature: Subcommand: dab apps
 			| influxdb       |
 			| kafka          |
 			| logspout       |
+			| mailhog        |
 			| memcached      |
 			| mitmproxy      |
 			| mysql          |


### PR DESCRIPTION
## Change Description

SMTP email testing

- SMTP server in docker and store in memory by default. Configure dev application to use mailhog limits risk of spamming your SMTP mail infrastructure. 
- View email using docker logs
- View email using web interface
- Lightweight 19MB image
- For other benefits see https://github.com/mailhog/MailHog

