### PR TITLE
Athens go module proxy app

### DIFF
--- a/app/docker/docker-compose.athens.yml
+++ b/app/docker/docker-compose.athens.yml
@@ -1,0 +1,35 @@
+version: '3.5'
+
+services:
+
+  athens:
+    container_name: dab_athens
+    image: "${DAB_APPS_ATHENS_IMAGE:-gomods/athens}:${DAB_APPS_ATHENS_TAG:-latest}"
+    labels:
+      description: 'Go Modules Proxy'
+      com.centurylinklabs.watchtower.enable: 'true'
+    restart: on-failure
+    expose:
+      - 3000
+    ports:
+      - "${DAB_APPS_ATHENS_PORT:-3000}:3000"
+    env_file:
+      - /tmp/denvmux/athens.env
+    environment:
+      ATHENS_STORAGE_TYPE: 'disk'
+      ATHENS_DISK_STORAGE_ROOT: '/var/lib/athens'
+    volumes:
+      - athens:/var/lib/athens
+    networks:
+      - default
+      - lab
+
+volumes:
+  athens:
+
+networks:
+  default:
+    name: dab_apps
+  lab:
+    external:
+      name: lab

--- a/tests/features/apps.feature
+++ b/tests/features/apps.feature
@@ -80,6 +80,7 @@ Feature: Subcommand: dab apps
 
 		Examples:
 			| APP            |
+			| athens         |
 			| consul         |
 			| deck-chores    |
 			| docker-gen     |


### PR DESCRIPTION
## Change Description

Adding the Athens go module proxy app: https://docs.gomods.io

Note that the image can be overridden by a env variable, as I have a company-used custom built image that overrides some git configuration within the container but this is not likely to be required for most users.

