### PR TITLE
Added optional client_variant arg to groups cmd

### DIFF
--- a/app/subcommands/group/run
+++ b/app/subcommands/group/run
@@ -6,14 +6,16 @@ set -eu
 
 [ -n "${1:-}" ] || fatality 'must provide a group name to add too'
 group_name="$1"
+client_variant="${2:-}"
 
 run_with_dependencies() {
 	depcmd="$1"
 	configkey="$2"
+	clientvariant="${3:-}"
 	configpath="$(config_path "$configkey")"
 	[ -f "$configpath" ] || return 0
-	xargs -I{} sh -c "$depcmd {}" <"$configpath"
+	xargs -I{} sh -c "$depcmd {} $clientvariant" <"$configpath"
 }
 
 run_with_dependencies 'dab group start' "group/$group_name/groups"
-run_with_dependencies 'dab repo entrypoint run' "group/$group_name/repos"
+run_with_dependencies 'dab repo entrypoint run' "group/$group_name/repos" "$client_variant"

--- a/app/subcommands/group/run
+++ b/app/subcommands/group/run
@@ -13,7 +13,7 @@ run_with_dependencies() {
 	shift 2
 	configpath="$(config_path "$configkey")"
 	[ -f "$configpath" ] || return 0
-	xargs -I{} sh -c "$depcmd {} ${@:-}" <"$configpath"
+	xargs -I{} sh -c "$depcmd {} $@" <"$configpath"
 }
 
 run_with_dependencies 'dab group start' "group/$group_name/groups"

--- a/app/subcommands/group/run
+++ b/app/subcommands/group/run
@@ -13,7 +13,7 @@ run_with_dependencies() {
 	shift 2
 	configpath="$(config_path "$configkey")"
 	[ -f "$configpath" ] || return 0
-	xargs -I{} sh -c "$depcmd {} $@" <"$configpath"
+	xargs -I{} sh -c "$depcmd {} $*" <"$configpath"
 }
 
 run_with_dependencies 'dab group start' "group/$group_name/groups"

--- a/app/subcommands/group/run
+++ b/app/subcommands/group/run
@@ -6,16 +6,15 @@ set -eu
 
 [ -n "${1:-}" ] || fatality 'must provide a group name to add too'
 group_name="$1"
-client_variant="${2:-}"
-
+shift
 run_with_dependencies() {
 	depcmd="$1"
 	configkey="$2"
-	clientvariant="${3:-}"
+	shift 2
 	configpath="$(config_path "$configkey")"
 	[ -f "$configpath" ] || return 0
-	xargs -I{} sh -c "$depcmd {} $clientvariant" <"$configpath"
+	xargs -I{} sh -c "$depcmd {} ${@:-}" <"$configpath"
 }
 
 run_with_dependencies 'dab group start' "group/$group_name/groups"
-run_with_dependencies 'dab repo entrypoint run' "group/$group_name/repos" "$client_variant"
+run_with_dependencies 'dab repo entrypoint run' "group/$group_name/repos" "$@"


### PR DESCRIPTION
## Change Description

Added optional argument to the group run command which take in a string and appends it to each instance of a service run with the run_with_dependencies function

## Relevant Issue(s)

- Allows groups to be run with required arguments for client specific variations of services instead of running a default cluster-lite then manually re-running client specific services

Closes #416 if merged.

