### PR TITLE
Make 'dab group start' fail fast

### DIFF
--- a/app/subcommands/group/run
+++ b/app/subcommands/group/run
@@ -12,7 +12,10 @@ run_with_dependencies() {
 	configkey="$2"
 	configpath="$(config_path "$configkey")"
 	[ -f "$configpath" ] || return 0
-	xargs -I{} sh -c "$depcmd {}" <"$configpath"
+	while read -r dep; do
+		# shellcheck disable=SC2086
+		$depcmd $dep </dev/null || fatality "$depcmd $dep exploded"
+	done <"$configpath"
 }
 
 run_with_dependencies 'dab group start' "group/$group_name/groups"


### PR DESCRIPTION
## Change Description

Make 'dab group start' fail fast

## Relevant Issue(s)

- Closes and fixes #418 
