### PR TITLE
Lock docker-compose to 1.24.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN apk add --no-cache --virtual .toolchain \
     python3-dev libffi-dev openssl-dev build-base \
  && apk add --no-cache docker-cli python3 \
  && rm -f /usr/bin/dockerd /usr/bin/docker-containerd* \
- && pip3 install docker-compose asciinema \
+ && pip3 install "docker-compose>=1.24.0,<1.25.0" asciinema \
  && apk del .toolchain \
  && rm -rf ~/.cache
 


### PR DESCRIPTION
## Change Description

Fixes #420 caused by recent breaking changes upstream in 1.25.0 but
should be fixed once 1.25.1 is released at which time this can and
should be reverted.

## Relevant Issue(s)

- Increment of #420
