### PR TITLE
Pin ansible base image for continued py-jinja2 support

### DIFF
--- a/app/docker/Dockerfile.ansible
+++ b/app/docker/Dockerfile.ansible
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.10.0
 
 RUN apk add --no-cache --virtual build-dependencies \
       gcc musl-dev libffi-dev openssl-dev python-dev \


### PR DESCRIPTION
alpine:latest no longer has support for the py-jinja2 package

## Change Description

Specify last version of alpine that supported py-ninja2 package

## Relevant Issue(s)

- Increment of #
- Closes #
- Fixes #
