### PR TITLE
Exclude merge commits from the changelog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY ./.git ./
 RUN git rev-parse HEAD > /VERSION \
  && git clone https://github.com/Nekroze/dab.git \
  && cd dab \
- && git log --graph --pretty=format:'\e[0;31m%h\e[0m|↓|%s \e[0;34m<%an>\e[0m' --abbrev-commit | tac > /LOG
+ && git log --graph --pretty=format:'\e[0;31m%h\e[0m|↓|%s \e[0;34m<%an>\e[0m' --abbrev-commit | grep -v '|↓|Merge ' | tac > /LOG
 
 # Stage some files here so that the final image has less layers
 FROM alpine:latest AS prep


### PR DESCRIPTION


## Change Description

This is a common hurdle to people contributing to this project. People often are asked to rebase and then never return, due to the github fork model this leaves an MR open forever that while easy to fix, no one can but the original author.

Hopefully this can loosen up the requirements so people do not have to grok rebase to contribute.
