### PR TITLE
Allow external sources for shellcheck

### DIFF
--- a/app/subcommands/repo/entrypoint/run
+++ b/app/subcommands/repo/entrypoint/run
@@ -29,6 +29,6 @@ if [ ! -x "$entrypoint" ]; then
 fi
 
 cd "$DAB_REPO_PATH/$repo"
-shellcheck --shell sh --color "$entrypoint" || true
+shellcheck --external-sources --shell sh --color "$entrypoint" || true
 env HOST_PWD="$DAB_REPO_PATH/$repo" \
 	sh "$entrypoint" "$@"


### PR DESCRIPTION
## Change Description

Allow shellcheck to specify external sources
when including scripts for var based paths.

For example:

\# shellcheck source=repo/project/files/script.sh
. "$DAB_CONF_PATH/repo/project/files/script.sh"
