### PR TITLE
Fix build issues with python 2 vs 3 name changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
   Shellcheck:
     docker:
-      - image: koalaman/shellcheck-alpine:stable 
+      - image: koalaman/shellcheck-alpine:stable
     steps:
       - checkout
 
@@ -200,4 +200,3 @@ jobs:
       - run:
           name: request
           command: ./scripts/request-stable-update.sh
-

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 export TEST_DOCKER=local
+export DAB_AUTOUPDATE=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ LABEL org.label-schema.schema-version="1.0" \
 # they are to be kept at a lower layer for caching.
 RUN apk add --no-cache --virtual .toolchain \
     python3-dev libffi-dev openssl-dev build-base \
- && apk add --no-cache docker-cli python3 \
+ && apk add --no-cache docker-cli python3 py3-pip py3-cryptography \
  && rm -f /usr/bin/dockerd /usr/bin/docker-containerd* \
  && pip3 install "docker-compose>=1.24.0,<1.25.0" asciinema \
  && apk del .toolchain \

--- a/app/docker/Dockerfile.sqliv
+++ b/app/docker/Dockerfile.sqliv
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.10.0
 
 RUN apk add --no-cache ca-certificates alpine-sdk python2 python2-dev libxslt-dev libxml2-dev py-pip git \
  && update-ca-certificates

--- a/app/docker/Dockerfile.xsstrike
+++ b/app/docker/Dockerfile.xsstrike
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --no-cache ca-certificates python3 git \
+RUN apk add --no-cache ca-certificates python3 py3-pip git \
  && update-ca-certificates
 
 ARG XSSTRIKE_VERSION=3.0.3

--- a/app/docker/docker-compose.mitmproxy.yml
+++ b/app/docker/docker-compose.mitmproxy.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - 8080
       - 8081
-    command: mitmweb --web-iface 0.0.0.0 --ssl-insecure
+    command: mitmweb --web-host 0.0.0.0 --ssl-insecure
     tmpfs:
       - /tmp
 

--- a/app/subcommands/pki/ready
+++ b/app/subcommands/pki/ready
@@ -68,7 +68,7 @@ nssdb_inject() {
 }
 
 for nssdb in $(find_nssdbs); do
-	carelessly nssdb_inject "$nssdb"
+	carelessly nssdb_inject "$nssdb" || true
 done
 
 if [ ! -f ~/.mitmproxy/mitmproxy-ca.pem ] || [ ! -f ~/.mitmproxy/mitmproxy-ca-cert.pem ]; then

--- a/tests/features/config.feature
+++ b/tests/features/config.feature
@@ -144,9 +144,9 @@ Feature: Subcommand: dab config
 	Scenario: You cannot make a namespace a key
 		Under everything namespaces are directories and so have the same properties.
 
-		Given I successfully run `dab config set asguard/thor "The O'Neill"`
+		Given I successfully run `dab config set asguard/thor myth`
 
-		When I run `dab config set asguard lost`
+		When I run `dab config set asguard alien`
 
 		Then it should fail with "Is a directory"
 


### PR DESCRIPTION
## Change Description

Alpine package names on their latest versions have been changed and can
now install the binary cryptography module from the package manager.
Some other changes to include pip or enforce an older alpine version
where python 2 is already specified.

Includes small test change to avoid issues with escaping inside gherkin files.

## Relevant Issue(s)
- https://app.circleci.com/pipelines/github/Nekroze/dab/1438/workflows/b7c30d5c-da55-43c7-aa4b-cb31c2119c13/jobs/3802
