### PR TITLE
Add Docker Compose v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
 version: 2.1
 
-notify:
-  webhooks:
-    - url: 'https://webhooks.gitter.im/e/cc6aefa009b39156b845'
-
 workflows:
   version: 2
 
@@ -46,13 +42,9 @@ jobs:
 
   Shfmt:
     docker:
-      - image: golang:1.12
+      - image: mvdan/shfmt:v3-alpine
     steps:
       - checkout
-
-      - run:
-          name: install
-          command: go get mvdan.cc/sh/cmd/shfmt
 
       - run:
           name: check
@@ -60,18 +52,13 @@ jobs:
 
   GolangCI-Lint:
     docker:
-      - image: golang:1.12
+      - image: golangci/golangci-lint:v1.15.0
     steps:
       - checkout
 
       - run:
-          name: install
-          command: |
-              curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.15.0
-
-      - run:
           name: get deps
-          command: go mod download
+          command: cd completion && go mod download
           environment:
             GO111MODULE: 'on'
 
@@ -111,6 +98,11 @@ jobs:
           command: ./scripts/build.sh
 
       - run:
+          name: Create tmp folder
+          command:
+            mkdir -p /tmp
+
+      - run:
           name: Smoke Tests
           command: script -qec './scripts/test.sh'
           environment:
@@ -119,6 +111,7 @@ jobs:
 
       - store_test_results:
           path: /tmp/dab/test_results
+
       - run:
           name: Clear test results
           when: on_fail
@@ -133,6 +126,7 @@ jobs:
 
       - store_test_results:
           path: /tmp/dab/test_results
+
       - run:
           name: Clear test results
           when: on_fail
@@ -159,6 +153,7 @@ jobs:
 
       - store_test_results:
           path: /tmp/dab/test_results
+
       - run:
           name: Clear test results
           when: on_fail
@@ -176,7 +171,6 @@ jobs:
             curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
             chmod +x ~/docker-compose
             sudo mv ~/docker-compose /usr/local/bin/docker-compose
-
 
       - run:
           name: Profile

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ LABEL org.label-schema.schema-version="1.0" \
 # they are to be kept at a lower layer for caching.
 RUN apk add --no-cache --virtual .toolchain \
     python3-dev libffi-dev openssl-dev build-base \
- && apk add --no-cache docker-cli python3 py3-pip py3-cryptography \
+ && apk add --no-cache docker-cli docker-cli-compose python3 py3-pip py3-cryptography \
  && rm -f /usr/bin/dockerd /usr/bin/docker-containerd* \
  && pip3 install "docker-compose>=1.24.0,<1.25.0" asciinema \
  && apk del .toolchain \

--- a/app/bin/dar-link-dest
+++ b/app/bin/dar-link-dest
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export HOST_PWD=$PWD
+export HOST_PWD="$PWD"
 exec dab apps run "$(basename "$0")" "$@"

--- a/app/bin/maybe_update_wrapper
+++ b/app/bin/maybe_update_wrapper
@@ -5,10 +5,12 @@ file_hash() {
 	"${FILE_HASH_ALGO:-md5}sum" "$1" | cut -d' ' -f1
 }
 
-if [ "${DAB_AUTOUPDATE:-true}" = 'false' ] || [ "${DAB_AUTOUPDATE_WRAPPER:-true}" = 'false' ] || ! [ -f /tmp/wrapper ] || ! [ -f "$DAB/dab" ]; then
+DAB_WRAPPER_FILENAME="$(basename "$DAB_WRAPPER_PATH")"
+
+if [ "${DAB_AUTOUPDATE:-true}" = 'false' ] || [ "${DAB_AUTOUPDATE_WRAPPER:-true}" = 'false' ] || ! [ -f "/tmp/wrapper/$DAB_WRAPPER_FILENAME" ] || ! [ -f "$DAB/dab" ]; then
 	return 0
-elif [ -r /tmp/wrapper ] && [ -r "$DAB/dab" ] && [ "$(file_hash "$DAB/dab")" != "$(file_hash /tmp/wrapper)" ]; then
-	if cat "$DAB/dab" >/tmp/wrapper; then
+elif [ -r "/tmp/wrapper/$DAB_WRAPPER_FILENAME" ] && [ -r "$DAB/dab" ] && [ "$(file_hash "$DAB/dab")" != "$(file_hash "/tmp/wrapper/$DAB_WRAPPER_FILENAME")" ]; then
+	if cat "$DAB/dab" >"/tmp/wrapper/$DAB_WRAPPER_FILENAME"; then
 		warn "Dab wrapper script at $DAB_WRAPPER_PATH was updated!"
 	else
 		error "Dab wrapper script at $DAB_WRAPPER_PATH could NOT be automatically updated!"

--- a/app/bin/query_user
+++ b/app/bin/query_user
@@ -5,7 +5,7 @@ set -eu
 
 message="${1:-Are you sure you would like to proceed?}"
 while true; do
-	# shellcheck disable=SC2039
+	# shellcheck disable=SC3045
 	read -r -p "$message " yn
 	case $yn in
 	[Yy]*) return 0 ;;

--- a/app/docker/docker-compose.mitmproxy.yml
+++ b/app/docker/docker-compose.mitmproxy.yml
@@ -4,7 +4,7 @@ services:
 
   mitmproxy:
     container_name: dab_mitmproxy
-    image: "mitmproxy/mitmproxy:${DAB_APPS_MITMPROXY_TAG:-latest}"
+    image: "mitmproxy/mitmproxy:${DAB_APPS_MITMPROXY_TAG:-6.0.2}"
     labels:
       description: 'HTTP debuging swiss-army knife, connect and go to http://mitm.it to load certs'
       com.centurylinklabs.watchtower.enable: 'true'

--- a/app/lib/hooks.sh
+++ b/app/lib/hooks.sh
@@ -71,7 +71,7 @@ maybe_set_kubeconfig() {
 		[ -f "$app_kubeconfig" ] &&
 		[ ! -f ~/.kube/config.yaml ] &&
 		[ ! -f ~/.kube/config.yml ]; then
-		export KUBECONFIG=$app_kubeconfig
+		export KUBECONFIG="$app_kubeconfig"
 	fi
 }
 

--- a/app/subcommands/repo/entrypoint/run
+++ b/app/subcommands/repo/entrypoint/run
@@ -16,7 +16,7 @@ suffix="$*"
 [ -n "$suffix" ] && suffix=" $suffix"
 inform "Executing $repo entrypoint $entry$suffix"
 
-export DAB_CURRENT_REPO=$repo
+export DAB_CURRENT_REPO="$repo"
 
 entrypoint="$DAB_CONF_PATH/repo/$repo/entrypoint/$entry"
 if [ ! -x "$entrypoint" ]; then

--- a/dab
+++ b/dab
@@ -145,7 +145,7 @@ if [ -z "${DAB_WRAPPER_PATH:-}" ]; then
 		export DAB_WRAPPER_PATH="$wrappercmd"
 	fi
 fi
-[ -n "${DAB_WRAPPER_PATH:-}" ] && dArg -v "$DAB_WRAPPER_PATH:/tmp/wrapper"
+[ -n "${DAB_WRAPPER_PATH:-}" ] && dArg -v "$(dirname "$DAB_WRAPPER_PATH"):/tmp/wrapper"
 
 # Pass through host OS type.
 dArg -e DAB_HOST_UNAME="$(uname)"


### PR DESCRIPTION
Add docker compose v2
* Install docker compose v2 (docker-cli-compose package)


Tests
* Had troubles with the test or feature that updates the wrapper file. With the file being docker mounted, it was not easily able to update the file in place. I've switched this to mount the containing folder instead which works well.
* Pin mitmproxy version to v6 so the health check works (it needs wget)
* Swapped to official linter images shfmt and golangci-lint rather than using a golangci-lint and installing ourselves
* Updated various shellcheck quoting issues
* Gitter webhook wasn't working so I've dropped it from circleci config

