### PR TITLE
Add docker-cli-buildx package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,15 +69,15 @@ LABEL org.label-schema.schema-version="1.0" \
 # they are to be kept at a lower layer for caching.
 RUN apk add --no-cache --virtual .toolchain \
     python3-dev libffi-dev openssl-dev build-base \
- && apk add --no-cache docker-cli docker-cli-compose python3 py3-pip py3-cryptography \
+ && apk add --no-cache docker-cli docker-cli-buildx docker-cli-compose python3 py3-pip py3-cryptography \
  && rm -f /usr/bin/dockerd /usr/bin/docker-containerd* \
- && pip3 install "docker-compose>=1.24.0,<1.25.0" asciinema \
+ && pip3 install --break-system-packages "docker-compose>=1.24.0,<1.25.0" asciinema \
  && apk del .toolchain \
  && rm -rf ~/.cache
 
 # Misc tools required for scripts.
 RUN apk add --no-cache git openssh tree util-linux jq nss-tools multitail ca-certificates highlight libintl entr postgresql-client task bash \
- && pip3 install yq \
+ && pip3 install --break-system-packages yq \
  && echo "check_mail:0" >> /etc/multitail.conf \
  && chmod 666 /etc/passwd
 

--- a/app/docker/Dockerfile.cyberchef
+++ b/app/docker/Dockerfile.cyberchef
@@ -1,4 +1,7 @@
 ARG NGINX_TAG=alpine
 FROM "nginx:$NGINX_TAG"
 
-ADD --chown=nginx:nginx https://gchq.github.io/CyberChef/cyberchef.htm /usr/share/nginx/html/index.html
+WORKDIR /usr/share/nginx/html
+
+RUN wget -qO- https://github.com/gchq/CyberChef/releases/download/v10.8.2/CyberChef_v10.8.2.zip \
+	| busybox unzip - && chown nginx:nginx * -R

--- a/app/docker/Dockerfile.remote_syslog2
+++ b/app/docker/Dockerfile.remote_syslog2
@@ -1,7 +1,6 @@
 FROM golang:latest
 
-RUN go get -d -v github.com/papertrail/remote_syslog2 \
- && go install github.com/papertrail/remote_syslog2
+RUN go install github.com/papertrail/remote_syslog2
 
 COPY configs/remote_syslog2.yml /etc/log_files.yml
 

--- a/tests/Dockerfile.tourist
+++ b/tests/Dockerfile.tourist
@@ -21,7 +21,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 RUN pip2 install PyYAML spielbash \
- && pip3 install "asciinema==1.4.0"
+ && pip3 install --break-system-packages "asciinema==1.4.0"
 
 WORKDIR /root
 


### PR DESCRIPTION
Add docker-cli-buildx

DEPRECATED: The legacy builder is deprecated and will be removed in a future release. Install the buildx component to build images with BuildKit: https://docs.docker.com/go/buildx/